### PR TITLE
ci: only run typecheck and tests on main branch push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -17,14 +19,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Lint
-        run: bun run lint
-
       - name: Typecheck
         run: bun run typecheck
 
       - name: Test
         run: bun run test
-
-      - name: Format check
-        run: bun run format:check


### PR DESCRIPTION
## Summary

Update CI workflow to trigger on main branch push and only run TypeScript checking and unit tests, removing lint and format checks.

## Changes

- Add `push` trigger for main branch
- Remove lint step
- Remove format check step
- Keep only typecheck and test steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)