### PR TITLE
Add floating task progress panel

### DIFF
--- a/src/renderer/components/ChatInput.tsx
+++ b/src/renderer/components/ChatInput.tsx
@@ -1,4 +1,5 @@
 import { ArrowUp, Loader2, Paperclip, Square } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import AttachmentPreviewList from '@/components/AttachmentPreviewList';
@@ -27,6 +28,7 @@ interface ChatInputProps {
   modelPreference: ChatModelPreference;
   onModelPreferenceChange: (preference: ChatModelPreference) => void;
   isModelPreferenceUpdating?: boolean;
+  floatingPanel?: ReactNode;
 }
 
 export default function ChatInput({
@@ -44,7 +46,8 @@ export default function ChatInput({
   attachmentError,
   modelPreference,
   onModelPreferenceChange,
-  isModelPreferenceUpdating = false
+  isModelPreferenceUpdating = false,
+  floatingPanel
 }: ChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -244,8 +247,9 @@ export default function ChatInput({
   return (
     <div
       ref={containerRef}
-      className="absolute inset-x-0 bottom-0 z-10 px-4 pt-6 pb-5 [-webkit-app-region:no-drag]"
+      className="absolute inset-x-0 bottom-0 z-10 px-4 pb-5 [-webkit-app-region:no-drag]"
     >
+      {floatingPanel && <div className="mb-2">{floatingPanel}</div>}
       <div className="mx-auto max-w-3xl">
         <div
           className={`rounded-3xl bg-white/95 p-2 shadow-[0_20px_60px_rgba(15,23,42,0.15)] backdrop-blur-xl dark:bg-neutral-900/90 dark:shadow-[0_16px_50px_rgba(0,0,0,0.65)] ${

--- a/src/renderer/components/FloatingTaskPanel.tsx
+++ b/src/renderer/components/FloatingTaskPanel.tsx
@@ -1,0 +1,115 @@
+import { CheckCircle2, ChevronDown, ChevronRight, ChevronUp, Circle, ListTodo } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import type { ContentBlock, Message, TodoWriteInput } from '@/types/chat';
+
+interface TodoItem {
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed';
+}
+
+function extractLatestTodos(messages: Message[]): TodoItem[] | null {
+  // Walk messages in reverse to find the latest TodoWrite tool use
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== 'assistant' || typeof msg.content === 'string') continue;
+
+    const blocks = msg.content as ContentBlock[];
+    for (let j = blocks.length - 1; j >= 0; j--) {
+      const block = blocks[j];
+      if (block.type === 'tool_use' && block.tool?.name === 'TodoWrite') {
+        const input = block.tool.parsedInput as TodoWriteInput | undefined;
+        if (input?.todos) {
+          // Return null for empty todos so the panel hides when tasks are cleared
+          if (input.todos.length === 0) return null;
+          return input.todos.map((t) => ({
+            content: t.content,
+            status: t.status as TodoItem['status']
+          }));
+        }
+      }
+    }
+  }
+  return null;
+}
+
+interface FloatingTaskPanelProps {
+  messages: Message[];
+}
+
+export default function FloatingTaskPanel({ messages }: FloatingTaskPanelProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const todos = useMemo(() => extractLatestTodos(messages), [messages]);
+
+  if (!todos || todos.length === 0) return null;
+
+  const completedCount = todos.filter((t) => t.status === 'completed').length;
+  const totalCount = todos.length;
+  const progressPercent = Math.round((completedCount / totalCount) * 100);
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-2">
+      <div className="rounded-2xl border border-neutral-200/60 bg-white/95 shadow-lg shadow-black/5 backdrop-blur-xl dark:border-neutral-700/50 dark:bg-neutral-850/90 dark:shadow-black/30">
+        {/* Header */}
+        <button
+          type="button"
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          className="flex w-full items-center justify-between px-4 py-2.5"
+        >
+          <div className="flex items-center gap-2">
+            <ListTodo className="size-4 text-neutral-500 dark:text-neutral-400" />
+            <span className="text-sm font-medium text-neutral-700 dark:text-neutral-200">
+              Task Progress
+            </span>
+            <span className="text-xs text-neutral-400 dark:text-neutral-500">
+              {completedCount}/{totalCount}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            {/* Progress bar */}
+            <div className="h-1.5 w-16 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700">
+              <div
+                className="h-full rounded-full bg-green-500 transition-all duration-300 dark:bg-green-400"
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+            {isCollapsed ?
+              <ChevronDown className="size-3.5 text-neutral-400 dark:text-neutral-500" />
+            : <ChevronUp className="size-3.5 text-neutral-400 dark:text-neutral-500" />}
+          </div>
+        </button>
+
+        {/* Task list */}
+        {!isCollapsed && (
+          <div className="border-t border-neutral-100 px-4 pt-1.5 pb-3 dark:border-neutral-800">
+            <div className="space-y-1">
+              {todos.map((todo, index) => (
+                <div key={index} className="flex items-start gap-2 py-0.5">
+                  <span className="mt-0.5 flex-shrink-0">
+                    {todo.status === 'completed' ?
+                      <CheckCircle2 className="size-3.5 text-green-500 dark:text-green-400" />
+                    : todo.status === 'in_progress' ?
+                      <ChevronRight className="size-3.5 text-blue-500 dark:text-blue-400" />
+                    : <Circle className="size-3.5 text-neutral-300 dark:text-neutral-600" />}
+                  </span>
+                  <span
+                    className={`text-sm leading-snug ${
+                      todo.status === 'completed'
+                        ? 'text-neutral-400 line-through dark:text-neutral-500'
+                        : todo.status === 'in_progress'
+                          ? 'text-neutral-700 dark:text-neutral-200'
+                          : 'text-neutral-500 dark:text-neutral-400'
+                    }`}
+                  >
+                    {todo.content}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/pages/Chat.tsx
+++ b/src/renderer/pages/Chat.tsx
@@ -4,6 +4,7 @@ import { Group, Panel } from 'react-resizable-panels';
 import type { Artifact } from '@/components/ArtifactPanel';
 import ArtifactPanel from '@/components/ArtifactPanel';
 import ChatInput from '@/components/ChatInput';
+import FloatingTaskPanel from '@/components/FloatingTaskPanel';
 import MessageList from '@/components/MessageList';
 import ResizeHandle from '@/components/ResizeHandle';
 import Sidebar from '@/components/Sidebar';
@@ -555,6 +556,7 @@ export default function Chat({ onSettingsClick }: ChatProps) {
             modelPreference={modelPreference}
             onModelPreferenceChange={handleModelPreferenceChange}
             isModelPreferenceUpdating={isModelPreferenceUpdating}
+            floatingPanel={<FloatingTaskPanel messages={messages} />}
           />
         </Panel>
 


### PR DESCRIPTION
## Summary
Display task completion status as a floating card above the chat input. Extracts the latest TodoWrite data from messages and shows task progress with individual statuses and a visual progress bar. The panel collapses/expands and hides automatically when no tasks exist.

## Changes
- New FloatingTaskPanel component that scans message history for latest TodoWrite tool data
- Slot-style integration via `floatingPanel` prop in ChatInput
- Fixed layout calculation to avoid double-counting panel height in message list padding
- Corrected chevron icon directions for collapse/expand affordance
- Empty todos properly clear the panel instead of showing stale tasks

## Test Plan
- Verify panel appears when TodoWrite is present in messages
- Check panel hides when TodoWrite has empty todos array
- Test collapse/expand toggle button
- Verify message list scrolls correctly with panel visible
- Check styling in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)