### PR TITLE
fix: unify titlebar safe area with CSS variable

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -375,7 +375,7 @@ export default function Sidebar({
   return (
     <div className="flex h-full flex-col border-r border-neutral-200/70 bg-neutral-50/80 dark:border-neutral-800 dark:bg-neutral-900/50">
       {/* Drag region for macOS traffic lights */}
-      <div className="h-7 shrink-0 [-webkit-app-region:drag]" />
+      <div className="shrink-0 [-webkit-app-region:drag]" style={{ height: 'var(--titlebar-height)' }} />
 
       {/* Brand */}
       <div className="shrink-0 px-3 pb-2.5">

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -4,6 +4,6 @@
  */
 export default function TitleBar() {
   return (
-    <div className="pointer-events-none absolute top-0 right-0 left-0 z-40 h-12 [-webkit-app-region:drag]" />
+    <div className="pointer-events-none absolute top-0 right-0 left-0 z-40 [-webkit-app-region:drag]" style={{ height: 'var(--titlebar-height)' }} />
   );
 }

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -2,6 +2,11 @@
 
 @plugin '@tailwindcss/typography';
 
+/* macOS traffic-light safe area */
+:root {
+  --titlebar-height: 38px;
+}
+
 /* Custom scrollbar styling for a cleaner look */
 * {
   scrollbar-width: thin;

--- a/src/renderer/pages/Schedules.tsx
+++ b/src/renderer/pages/Schedules.tsx
@@ -189,8 +189,8 @@ export default function Schedules({ onBack }: SchedulesProps) {
   return (
     <div className="flex h-screen flex-col bg-white dark:bg-neutral-900">
       {/* Header */}
+      <div className="shrink-0 [-webkit-app-region:drag]" style={{ height: 'var(--titlebar-height)' }} />
       <div className="flex shrink-0 items-center gap-3 border-b border-neutral-200 px-4 py-3 dark:border-neutral-800">
-        <div className="h-7 [-webkit-app-region:drag]" />
         <button
           onClick={onBack}
           className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -301,9 +301,9 @@ function Settings({ onBack }: SettingsProps) {
 
   return (
     <div className="flex h-screen flex-col bg-linear-to-b from-neutral-50 via-white to-neutral-100 dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-950">
-      <div className="fixed top-0 right-0 left-0 z-50 h-12 [-webkit-app-region:drag]" />
+      <div className="fixed top-0 right-0 left-0 z-50 [-webkit-app-region:drag]" style={{ height: 'var(--titlebar-height)' }} />
 
-      <div className="flex flex-1 flex-col overflow-hidden pt-12">
+      <div className="flex flex-1 flex-col overflow-hidden" style={{ paddingTop: 'var(--titlebar-height)' }}>
         <div className="flex-1 overflow-y-auto px-6 pt-8 pb-16">
           <div className="mx-auto max-w-3xl space-y-8">
             <div className="flex flex-wrap items-start justify-between gap-4">

--- a/src/renderer/pages/Skills.tsx
+++ b/src/renderer/pages/Skills.tsx
@@ -129,8 +129,9 @@ export default function Skills({ onBack }: SkillsProps) {
   return (
     <div className="flex h-screen flex-col bg-white dark:bg-neutral-950">
       {/* Header with drag region */}
-      <div className="shrink-0 [-webkit-app-region:drag]">
-        <div className="flex items-center gap-3 px-4 pt-8 pb-3 [-webkit-app-region:no-drag]">
+      <div className="shrink-0 [-webkit-app-region:drag]" style={{ height: 'var(--titlebar-height)' }} />
+      <div className="shrink-0">
+        <div className="flex items-center gap-3 px-4 py-3 [-webkit-app-region:no-drag]">
           <button
             onClick={onBack}
             className="flex h-7 w-7 items-center justify-center rounded-lg text-neutral-500 transition hover:bg-neutral-100 hover:text-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"


### PR DESCRIPTION
## Summary
- Define `--titlebar-height: 38px` CSS variable for macOS traffic light safe area
- Replace inconsistent hardcoded values (`h-7`/28px, `h-12`/48px, `pt-8`/32px) across all pages
- Affected: Sidebar, TitleBar, Schedules, Skills, Settings

## Test plan
- [ ] Verify macOS traffic lights don't overlap content on all pages (Chat, Settings, Skills, Schedules)
- [ ] Verify window drag region works correctly
- [ ] Verify layout looks correct on non-macOS (Windows/Linux)

Generated with [Claude Code](https://claude.com/claude-code)