### PR TITLE
feat: redesign skill suggestions as pill tags with detail cards

### DIFF
--- a/src/renderer/components/SkillCardGrid.tsx
+++ b/src/renderer/components/SkillCardGrid.tsx
@@ -1,4 +1,13 @@
-import { BarChart3, FileText, Globe, Palette, PenLine, Sparkles } from 'lucide-react';
+import {
+  ArrowRight,
+  BarChart3,
+  FileText,
+  Globe,
+  Palette,
+  PenLine,
+  Sparkles,
+} from 'lucide-react';
+import { useState } from 'react';
 import type { ComponentType, SVGProps } from 'react';
 
 import type { SkillCard } from '@/constants/skillCards';
@@ -19,45 +28,105 @@ interface SkillCardGridProps {
 }
 
 export default function SkillCardGrid({ onSelectSkill, onMoreClick }: SkillCardGridProps) {
-  const handleClick = (card: SkillCard) => {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const selectedCard = skillCards.find((c) => c.id === selectedId);
+
+  const handlePillClick = (card: SkillCard) => {
     if (card.id === 'more') {
+      setSelectedId(null);
       onMoreClick?.();
       return;
     }
-    if (card.prefillPrompt) {
-      onSelectSkill(card.prefillPrompt);
+    setSelectedId((prev) => (prev === card.id ? null : card.id));
+  };
+
+  const handleUsePrompt = () => {
+    if (selectedCard?.prefillPrompt) {
+      onSelectSkill(selectedCard.prefillPrompt);
     }
   };
 
   return (
-    <div className="grid w-full max-w-2xl grid-cols-3 gap-2.5 px-4">
-      {skillCards.map((card) => {
-        const Icon = iconMap[card.icon];
-        return (
-          <button
-            key={card.id}
-            onClick={() => handleClick(card)}
-            className="group flex items-start gap-3 rounded-xl border border-neutral-200/60 bg-white/80 px-3.5 py-3 text-left transition hover:border-neutral-300/80 hover:bg-white hover:shadow-sm dark:border-neutral-800/60 dark:bg-neutral-800/40 dark:hover:border-neutral-700/80 dark:hover:bg-neutral-800/70"
-          >
-            <div
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
-              style={{
-                background: `linear-gradient(135deg, ${card.gradient.from}, ${card.gradient.to})`,
-              }}
+    <div className="flex w-full max-w-2xl flex-col items-center gap-3 px-4">
+      {/* Pill tags */}
+      <div className="flex flex-wrap justify-center gap-2">
+        {skillCards.map((card) => {
+          const Icon = iconMap[card.icon];
+          const isSelected = card.id === selectedId;
+          return (
+            <button
+              key={card.id}
+              onClick={() => handlePillClick(card)}
+              className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-all ${
+                isSelected
+                  ? 'border-neutral-400 bg-neutral-100 text-neutral-800 dark:border-neutral-500 dark:bg-neutral-700 dark:text-neutral-100'
+                  : 'border-neutral-200 bg-white text-neutral-600 hover:border-neutral-300 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:border-neutral-600 dark:hover:bg-neutral-750'
+              }`}
             >
-              <Icon className="h-4 w-4 text-white" />
-            </div>
-            <div className="min-w-0">
-              <div className="text-xs font-semibold text-neutral-800 dark:text-neutral-100">
-                {card.title}
+              <Icon
+                className="h-3.5 w-3.5"
+                style={{ color: card.gradient.from }}
+              />
+              {card.title}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Detail card */}
+      {selectedCard?.detail && (
+        <div className="w-full max-w-lg animate-in fade-in slide-in-from-top-2 duration-200">
+          <div className="rounded-xl border border-neutral-200/80 bg-white/90 p-4 shadow-sm backdrop-blur dark:border-neutral-700/80 dark:bg-neutral-800/90">
+            <div className="mb-3 flex items-center gap-2">
+              <div
+                className="flex h-6 w-6 items-center justify-center rounded-md"
+                style={{
+                  background: `linear-gradient(135deg, ${selectedCard.gradient.from}, ${selectedCard.gradient.to})`,
+                }}
+              >
+                {(() => {
+                  const Icon = iconMap[selectedCard.icon];
+                  return <Icon className="h-3.5 w-3.5 text-white" />;
+                })()}
               </div>
-              <div className="mt-0.5 text-[10px] leading-tight text-neutral-500 dark:text-neutral-400">
-                {card.description}
+              <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-100">
+                {selectedCard.title}
+              </span>
+              <span className="text-xs text-neutral-400 dark:text-neutral-500">
+                {selectedCard.description}
+              </span>
+            </div>
+
+            <div className="mb-3 space-y-2">
+              <div>
+                <div className="mb-0.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+                  示例提示词
+                </div>
+                <p className="text-xs leading-relaxed text-neutral-600 dark:text-neutral-300">
+                  {selectedCard.prefillPrompt}
+                </p>
+              </div>
+              <div>
+                <div className="mb-0.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+                  最终产物
+                </div>
+                <p className="text-xs leading-relaxed text-neutral-600 dark:text-neutral-300">
+                  {selectedCard.detail.output}
+                </p>
               </div>
             </div>
-          </button>
-        );
-      })}
+
+            <button
+              onClick={handleUsePrompt}
+              className="flex items-center gap-1 rounded-lg bg-neutral-800 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-neutral-700 dark:bg-neutral-200 dark:text-neutral-800 dark:hover:bg-neutral-300"
+            >
+              使用此提示词
+              <ArrowRight className="h-3 w-3" />
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/constants/skillCards.ts
+++ b/src/renderer/constants/skillCards.ts
@@ -5,9 +5,25 @@ export interface SkillCard {
   icon: 'FileText' | 'BarChart3' | 'PenLine' | 'Globe' | 'Palette' | 'Sparkles'
   gradient: { from: string; to: string }
   prefillPrompt: string | null
+  /** Detail card content shown when the pill is selected */
+  detail?: {
+    output: string
+  }
 }
 
 export const skillCards: SkillCard[] = [
+  {
+    id: 'web-app',
+    title: '创建应用',
+    description: '根据描述快速生成网页应用',
+    icon: 'Globe',
+    gradient: { from: '#8B5CF6', to: '#A855F7' },
+    prefillPrompt:
+      '帮我创建一个露营团建住宿统计应用，可以录入参与人员，选择是否住在营地，并汇总统计结果。',
+    detail: {
+      output: '可交互的网页应用，支持数据录入、实时统计和导出',
+    },
+  },
   {
     id: 'pdf',
     title: '处理 PDF',
@@ -16,6 +32,9 @@ export const skillCards: SkillCard[] = [
     gradient: { from: '#EF4444', to: '#F97316' },
     prefillPrompt:
       '请提取附件 PDF 中的关键数据和表格，并整理成结构化的摘要。',
+    detail: {
+      output: '结构化文本摘要、提取的表格数据或处理后的 PDF 文件',
+    },
   },
   {
     id: 'xlsx',
@@ -25,6 +44,9 @@ export const skillCards: SkillCard[] = [
     gradient: { from: '#22C55E', to: '#10B981' },
     prefillPrompt:
       '请分析附件中的表格数据，找出关键趋势，并生成带图表的分析报告。',
+    detail: {
+      output: '数据分析报告，包含趋势图表和关键洞察',
+    },
   },
   {
     id: 'docx',
@@ -34,15 +56,9 @@ export const skillCards: SkillCard[] = [
     gradient: { from: '#3B82F6', to: '#6366F1' },
     prefillPrompt:
       '请审阅附件文档的内容和结构，提供修改建议并生成带修订标记的版本。',
-  },
-  {
-    id: 'web-app',
-    title: '创建应用',
-    description: '根据描述快速生成网页应用',
-    icon: 'Globe',
-    gradient: { from: '#8B5CF6', to: '#A855F7' },
-    prefillPrompt:
-      '帮我创建一个露营团建住宿统计应用，可以录入参与人员，选择是否住在营地，并汇总统计结果。',
+    detail: {
+      output: '带批注和修订标记的 Word 文档',
+    },
   },
   {
     id: 'frontend-design',
@@ -52,6 +68,9 @@ export const skillCards: SkillCard[] = [
     gradient: { from: '#EC4899', to: '#F43F5E' },
     prefillPrompt:
       '设计一个现代风格的数据看板，包含侧边导航、数据卡片和图表区域，风格专业大气。',
+    detail: {
+      output: '高保真前端页面，可直接在浏览器中预览',
+    },
   },
   {
     id: 'more',


### PR DESCRIPTION
## Summary

Transform skill suggestion cards from a 3-column grid into pill-shaped tags with expandable detail cards. When users click a pill, a detail card appears below showing the example prompt and expected output, helping them understand each capability before committing.

## Changes

- Reorder "创建应用" to first position as the flagship feature
- Redesign cards as rounded pill buttons instead of 3-column grid layout  
- Add detail panel showing example prompt and expected output description
- Remove configuration duplication (example text now sourced from prefillPrompt)
- Fix stale detail card when clicking "更多场景" by clearing selection state

## Test Plan

- Click pills in the welcome screen to open/close detail cards
- Verify "使用此提示词" button populates the chat input with the correct prompt
- Confirm "更多场景" pill properly clears detail state when clicked
- Test dark mode styling on detail cards
- Verify pill selection state is visually distinct (highlight/border)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)