### PR TITLE
fix: separate hover and selected states in skill pills

### DIFF
--- a/src/renderer/components/SkillCardGrid.tsx
+++ b/src/renderer/components/SkillCardGrid.tsx
@@ -28,9 +28,11 @@ interface SkillCardGridProps {
 }
 
 export default function SkillCardGrid({ onSelectSkill, onMoreClick, currentInput = '' }: SkillCardGridProps) {
-  const [activeId, setActiveId] = useState<string | null>(null);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  const activeCard = skillCards.find((c) => c.id === activeId);
+  const hoveredCard = skillCards.find((c) => c.id === hoveredId);
+  const selectedCard = skillCards.find((c) => c.id === selectedId);
 
   const handleClick = useCallback(
     (card: SkillCard) => {
@@ -41,7 +43,7 @@ export default function SkillCardGrid({ onSelectSkill, onMoreClick, currentInput
       if (!card.prefillPrompt) return;
 
       if (currentInput.trim()) {
-        setActiveId(card.id);
+        setSelectedId(card.id);
       } else {
         onSelectSkill(card.prefillPrompt);
       }
@@ -50,31 +52,36 @@ export default function SkillCardGrid({ onSelectSkill, onMoreClick, currentInput
   );
 
   const handleConfirmReplace = useCallback(() => {
-    if (activeCard?.prefillPrompt) {
-      onSelectSkill(activeCard.prefillPrompt);
+    if (selectedCard?.prefillPrompt) {
+      onSelectSkill(selectedCard.prefillPrompt);
     }
-    setActiveId(null);
-  }, [activeCard, onSelectSkill]);
+    setSelectedId(null);
+  }, [selectedCard, onSelectSkill]);
 
   return (
     <div className="flex w-full max-w-2xl flex-col items-center gap-2 px-4">
       <div className="flex flex-wrap justify-center gap-2">
         {skillCards.map((card) => {
           const Icon = iconMap[card.icon];
+          const isSelected = selectedId === card.id;
           return (
             <button
               key={card.id}
               onClick={() => handleClick(card)}
-              onMouseEnter={() => !activeId && setActiveId(card.id)}
-              onMouseLeave={() => !currentInput.trim() && setActiveId(null)}
-              onFocus={() => !activeId && setActiveId(card.id)}
-              onBlur={() => !currentInput.trim() && setActiveId(null)}
+              onMouseEnter={() => setHoveredId(card.id)}
+              onMouseLeave={() => setHoveredId(null)}
+              onFocus={() => setHoveredId(card.id)}
+              onBlur={() => setHoveredId(null)}
               aria-label={`${card.title}: ${card.example}`}
-              className="flex items-center gap-1.5 rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-xs font-medium text-neutral-600 transition-all hover:border-neutral-300 hover:bg-neutral-50 focus-visible:ring-2 focus-visible:ring-neutral-400/50 active:scale-[0.97] dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:border-neutral-600 dark:hover:bg-neutral-750"
+              className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-all focus-visible:ring-2 focus-visible:ring-neutral-400/50 active:scale-[0.97] ${
+                isSelected
+                  ? 'border-neutral-400 bg-neutral-800 text-white dark:border-neutral-400 dark:bg-neutral-200 dark:text-neutral-900'
+                  : 'border-neutral-200 bg-white text-neutral-600 hover:border-neutral-300 hover:bg-neutral-100 hover:text-neutral-900 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:border-neutral-500 dark:hover:bg-neutral-700 dark:hover:text-neutral-100'
+              }`}
             >
               <Icon
                 className="h-3.5 w-3.5"
-                style={{ color: card.iconColor }}
+                style={{ color: isSelected ? undefined : card.iconColor }}
               />
               {card.title}
             </button>
@@ -84,12 +91,12 @@ export default function SkillCardGrid({ onSelectSkill, onMoreClick, currentInput
 
       {/* Hint / confirmation */}
       <div className="h-5">
-        {activeCard?.example && !currentInput.trim() && (
+        {hoveredCard?.example && !selectedId && (
           <p className="animate-in fade-in duration-150 text-xs text-neutral-400 dark:text-neutral-500">
-            例: {activeCard.example}
+            例: {hoveredCard.example}
           </p>
         )}
-        {activeCard?.prefillPrompt && currentInput.trim() && (
+        {selectedCard?.prefillPrompt && (
           <p className="animate-in fade-in duration-150 text-xs text-neutral-400 dark:text-neutral-500">
             将替换当前输入 —{' '}
             <button


### PR DESCRIPTION
## Summary
- Split `activeId` into `hoveredId` and `selectedId` to fix state confusion
- Improved hover contrast: darker background with lighter text in both light and dark modes
- Selected pills now persist with high-contrast reverse colors for clear visual feedback

## Issues Fixed
1. Poor text contrast when hovering pills in dark mode
2. No visual indication of selected pill after mouse leaves

## Test Plan
- [ ] Hover over a skill pill — verify text becomes more visible
- [ ] Click a pill with existing input text — verify pill turns dark (light mode) or light (dark mode)
- [ ] Move mouse away from selected pill — verify selection styling persists
- [ ] Hover a different pill while one is selected — verify selection doesn't change
- [ ] Click "确认替换" — verify selected pill deselects and input is replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)