### PR TITLE
Restore skill card details and fix header buttons

### DIFF
--- a/src/renderer/components/SkillCardGrid.tsx
+++ b/src/renderer/components/SkillCardGrid.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowRight,
   BarChart3,
   FileText,
   Globe,
@@ -28,60 +29,60 @@ interface SkillCardGridProps {
 }
 
 export default function SkillCardGrid({ onSelectSkill, onMoreClick, currentInput = '' }: SkillCardGridProps) {
-  const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [confirmedInput, setConfirmedInput] = useState<string | null>(null);
 
-  const hoveredCard = skillCards.find((c) => c.id === hoveredId);
   const selectedCard = skillCards.find((c) => c.id === selectedId);
+  const isConfirmed = confirmedInput !== null && confirmedInput === currentInput;
 
-  const handleClick = useCallback(
+  const handlePillClick = useCallback(
     (card: SkillCard) => {
       if (card.id === 'more') {
+        setSelectedId(null);
         onMoreClick?.();
         return;
       }
-      if (!card.prefillPrompt) return;
-
-      if (currentInput.trim()) {
-        setSelectedId(card.id);
-      } else {
-        onSelectSkill(card.prefillPrompt);
-      }
+      setSelectedId((prev) => (prev === card.id ? null : card.id));
+      setConfirmedInput(null);
     },
-    [onMoreClick, onSelectSkill, currentInput],
+    [onMoreClick],
   );
 
-  const handleConfirmReplace = useCallback(() => {
-    if (selectedCard?.prefillPrompt) {
-      onSelectSkill(selectedCard.prefillPrompt);
+  const handleUsePrompt = useCallback(() => {
+    if (!selectedCard?.prefillPrompt) return;
+
+    if (currentInput.trim() && !isConfirmed) {
+      setConfirmedInput(currentInput);
+      return;
     }
+
+    onSelectSkill(selectedCard.prefillPrompt);
     setSelectedId(null);
-  }, [selectedCard, onSelectSkill]);
+    setConfirmedInput(null);
+  }, [selectedCard, currentInput, isConfirmed, onSelectSkill]);
 
   return (
-    <div className="flex w-full max-w-2xl flex-col items-center gap-2 px-4">
+    <div className="flex w-full max-w-2xl flex-col items-center gap-3 px-4">
+      {/* Pill tags */}
       <div className="flex flex-wrap justify-center gap-2">
         {skillCards.map((card) => {
           const Icon = iconMap[card.icon];
-          const isSelected = selectedId === card.id;
+          const isSelected = card.id === selectedId;
           return (
             <button
               key={card.id}
-              onClick={() => handleClick(card)}
-              onMouseEnter={() => setHoveredId(card.id)}
-              onMouseLeave={() => setHoveredId(null)}
-              onFocus={() => setHoveredId(card.id)}
-              onBlur={() => setHoveredId(null)}
-              aria-label={`${card.title}: ${card.example}`}
-              className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-all focus-visible:ring-2 focus-visible:ring-neutral-400/50 active:scale-[0.97] ${
+              onClick={() => handlePillClick(card)}
+              aria-label={`${card.title}: ${card.description}`}
+              aria-expanded={isSelected && !!card.detail}
+              className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-all active:scale-[0.97] focus-visible:ring-2 focus-visible:ring-neutral-400/50 ${
                 isSelected
-                  ? 'border-neutral-400 bg-neutral-800 text-white dark:border-neutral-400 dark:bg-neutral-200 dark:text-neutral-900'
-                  : 'border-neutral-200 bg-white text-neutral-600 hover:border-neutral-300 hover:bg-neutral-100 hover:text-neutral-900 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:border-neutral-500 dark:hover:bg-neutral-700 dark:hover:text-neutral-100'
+                  ? 'border-neutral-400 bg-neutral-100 text-neutral-800 dark:border-neutral-500 dark:bg-neutral-700 dark:text-neutral-100'
+                  : 'border-neutral-200 bg-white text-neutral-600 hover:border-neutral-300 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:border-neutral-600 dark:hover:bg-neutral-750'
               }`}
             >
               <Icon
                 className="h-3.5 w-3.5"
-                style={{ color: isSelected ? undefined : card.iconColor }}
+                style={{ color: card.iconColor }}
               />
               {card.title}
             </button>
@@ -89,25 +90,65 @@ export default function SkillCardGrid({ onSelectSkill, onMoreClick, currentInput
         })}
       </div>
 
-      {/* Hint / confirmation */}
-      <div className="h-5">
-        {hoveredCard?.example && !selectedId && (
-          <p className="animate-in fade-in duration-150 text-xs text-neutral-400 dark:text-neutral-500">
-            例: {hoveredCard.example}
-          </p>
-        )}
-        {selectedCard?.prefillPrompt && (
-          <p className="animate-in fade-in duration-150 text-xs text-neutral-400 dark:text-neutral-500">
-            将替换当前输入 —{' '}
+      {/* Detail card */}
+      {selectedCard?.detail && (
+        <div className="w-full max-w-lg animate-in fade-in slide-in-from-top-2 duration-200">
+          <div className="rounded-xl border border-neutral-200/80 bg-white/90 p-4 shadow-sm backdrop-blur dark:border-neutral-700/80 dark:bg-neutral-800/90">
+            <div className="mb-3 flex items-center gap-2">
+              <div
+                className="flex h-6 w-6 items-center justify-center rounded-md"
+                style={{ backgroundColor: selectedCard.iconColor }}
+              >
+                {(() => {
+                  const Icon = iconMap[selectedCard.icon];
+                  return <Icon className="h-3.5 w-3.5 text-white" />;
+                })()}
+              </div>
+              <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-100">
+                {selectedCard.title}
+              </span>
+              <span className="text-xs text-neutral-400 dark:text-neutral-500">
+                {selectedCard.description}
+              </span>
+            </div>
+
+            <div className="mb-3 space-y-2">
+              <div>
+                <div className="mb-0.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+                  场景
+                </div>
+                <p className="text-xs leading-relaxed text-neutral-600 dark:text-neutral-300">
+                  {selectedCard.detail.background}
+                </p>
+              </div>
+              <div>
+                <div className="mb-0.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+                  安排任务
+                </div>
+                <p className="text-xs leading-relaxed text-neutral-600 dark:text-neutral-300">
+                  {selectedCard.detail.task}
+                </p>
+              </div>
+              <div>
+                <div className="mb-0.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+                  完成效果
+                </div>
+                <p className="text-xs leading-relaxed text-neutral-600 dark:text-neutral-300">
+                  {selectedCard.detail.output}
+                </p>
+              </div>
+            </div>
+
             <button
-              onClick={handleConfirmReplace}
-              className="text-neutral-600 underline hover:text-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-100"
+              onClick={handleUsePrompt}
+              className="flex items-center gap-1 rounded-lg bg-neutral-800 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-neutral-700 dark:bg-neutral-200 dark:text-neutral-800 dark:hover:bg-neutral-300"
             >
-              确认替换
+              {isConfirmed ? '确认替换当前输入' : '使用此场景'}
+              <ArrowRight className="h-3 w-3" />
             </button>
-          </p>
-        )}
-      </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/constants/skillCards.ts
+++ b/src/renderer/constants/skillCards.ts
@@ -1,65 +1,105 @@
 export interface SkillCard {
   id: string
   title: string
+  description: string
   icon: 'FileText' | 'BarChart3' | 'PenLine' | 'Globe' | 'Palette' | 'Sparkles'
   iconColor: string
-  /** One-line scenario shown below pills when selected */
-  example: string
   prefillPrompt: string | null
+  /** Detail card content shown when the pill is selected */
+  detail?: {
+    background: string
+    task: string
+    output: string
+  }
 }
 
 export const skillCards: SkillCard[] = [
   {
     id: 'web-app',
     title: '创建应用',
+    description: '根据描述快速生成网页应用',
     icon: 'Globe',
     iconColor: '#8B5CF6',
-    example: '做一个团建住宿统计页面，同事打开链接就能填写',
     prefillPrompt:
       '帮我创建一个露营团建住宿统计页面，同事打开链接后可以填写自己的姓名、选择住营地还是当天返回，提交后我能实时看到汇总结果。',
+    detail: {
+      background:
+        '公司安排小张组织一次露营形式的团建，他需要提前统计每个人是住在营地还是当天返回，方便安排帐篷和交通。',
+      task: '小张让小马快跑做一个统计页面，同事打开链接就能填写自己的住宿选择。',
+      output:
+        '生成了一个统计页面，小张把网址发到工作群，大家点进去填完后，小张那边就能实时看到谁住营地、谁当天返回。页面运行在本机上，只有同一网络内的同事才能打开。',
+    },
   },
   {
     id: 'pdf',
     title: '处理 PDF',
+    description: '提取内容、合并拆分、填写表单',
     icon: 'FileText',
     iconColor: '#EF4444',
-    example: '把对账单 PDF 里的表格提取成 Excel',
     prefillPrompt:
       '请帮我把附件中这份对账单 PDF 里的表格数据提取出来，整理成 Excel 表格，方便我逐项核对。',
+    detail: {
+      background:
+        '财务小李每月要核对十几家供应商发来的对账单，但对账单都是 PDF 格式，手动逐行比对既慢又容易出错。',
+      task: '小李把对账单 PDF 发给小马快跑，让它把里面的金额、日期、明细整理成表格。',
+      output:
+        '生成了一份整理好的 Excel 表格，金额、日期、明细一目了然，小李直接打开就能和系统里的数据逐项核对。',
+    },
   },
   {
     id: 'xlsx',
     title: '分析表格',
+    description: '数据分析、图表制作、公式计算',
     icon: 'BarChart3',
     iconColor: '#22C55E',
-    example: '分析各渠道销售数据，生成带图表的报告',
     prefillPrompt:
       '请分析附件中上季度各渠道的销售数据，找出增长最快和下滑最明显的渠道，做成带图表的分析报告。',
+    detail: {
+      background:
+        '市场部小王拿到了上季度各销售渠道的数据表，领导下周要看各渠道的增长情况，让他准备一份分析报告。',
+      task: '小王把数据表发给小马快跑，让它分析各渠道的增长趋势，生成一份带图表的报告。',
+      output:
+        '生成了一份带柱状图和趋势线的报告，哪个渠道在涨、哪个在跌一目了然，小王直接拿去给领导汇报。',
+    },
   },
   {
     id: 'docx',
     title: '编辑文档',
+    description: '创建、审阅、批注 Word 文档',
     icon: 'PenLine',
     iconColor: '#3B82F6',
-    example: '检查年会方案的措辞和格式，标注修改建议',
     prefillPrompt:
       '请帮我检查附件中的年会活动方案，看看有没有措辞不当、逻辑不通或格式不规范的地方，标注出来并给出修改建议。',
+    detail: {
+      background:
+        '行政小陈写好了公司年会的活动方案，提交给领导前想先检查一遍，避免有错别字或者逻辑漏洞。',
+      task: '小陈把方案文档发给小马快跑，让它帮忙检查措辞、格式和逻辑。',
+      output:
+        '生成了一份标注好的 Word 文档，有问题的地方都加了批注和修改建议，小陈照着改完就能放心提交。',
+    },
   },
   {
     id: 'frontend-design',
     title: '设计界面',
+    description: '打造高品质的前端页面',
     icon: 'Palette',
     iconColor: '#EC4899',
-    example: '设计一个数据看板，集中展示关键业务指标',
     prefillPrompt:
       '帮我设计一个内部数据看板页面，能展示今日订单量、销售额、客户数等关键指标，风格简洁清晰。',
+    detail: {
+      background:
+        '运营主管每天早上要登录好几个系统分别查看业务数据，想要一个页面能一眼看到所有关键指标。',
+      task: '运营主管让小马快跑设计一个数据看板页面，把分散在各系统的关键数字集中展示。',
+      output:
+        '生成了一个可以在浏览器中直接打开的看板页面，订单量、销售额、客户数等指标用卡片和图表呈现，每天打开就能一目了然。',
+    },
   },
   {
     id: 'more',
     title: '更多场景',
+    description: '探索其他能力',
     icon: 'Sparkles',
     iconColor: '#6B7280',
-    example: '',
     prefillPrompt: null,
   },
 ]

--- a/src/renderer/pages/Chat.tsx
+++ b/src/renderer/pages/Chat.tsx
@@ -637,7 +637,7 @@ export default function Chat({ onSettingsClick, onSkillsClick, onSchedulesClick,
         {/* Center: chat area */}
         <Panel minSize="300px" className="relative flex flex-col overflow-hidden" style={{ background: 'var(--color-content-bg)' }}>
           {/* Top bar with drag region and dropdown buttons */}
-          <div className="relative shrink-0">
+          <div className="relative shrink-0" style={{ height: 'var(--titlebar-height)' }}>
             <DragRegion />
             {/* Right-side dropdown buttons */}
             <div className="absolute top-1/2 right-3 z-10 flex -translate-y-1/2 items-center gap-1">
@@ -721,6 +721,7 @@ export default function Chat({ onSettingsClick, onSkillsClick, onSchedulesClick,
               </div>
               <SkillCardGrid
                 onSelectSkill={(prompt) => setInputValue(prompt)}
+                onMoreClick={onSkillsClick}
                 currentInput={inputValue}
               />
             </div>


### PR DESCRIPTION
## Summary

- Fix titlebar height causing top-right buttons (workspace, apps) to be invisible
- Restore three-section detail card design from PR #23 (场景/安排任务/完成效果)
- Fix "更多场景" button by connecting onMoreClick callback
- Improve input replacement confirmation to prevent stale state
- Add accessibility attributes (aria-expanded, focus-visible)

## Test plan

- [ ] Verify top-right dropdown buttons are now visible
- [ ] Click skill cards and verify three-section detail card appears
- [ ] Test "更多场景" button navigates to skills section
- [ ] Type text, select skill, click "使用此场景", then edit text and verify confirmation resets
- [ ] Test keyboard navigation and screen reader support with new aria attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)