### PR TITLE
feat: 输入框斜线命令自动补全

### DIFF
--- a/src/renderer/components/ChatInput.tsx
+++ b/src/renderer/components/ChatInput.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import AttachmentPreviewList from '@/components/AttachmentPreviewList';
+import SlashCommandMenu from '@/components/SlashCommandMenu';
+import { useSlashCommand } from '@/hooks/useSlashCommand';
 
 import type { ChatModelPreference } from '../../shared/types/ipc';
 import { MODEL_LABELS } from '../../shared/types/ipc';
@@ -61,6 +63,7 @@ export default function ChatInput({
   const dragCounterRef = useRef(0);
   const [isDragActive, setIsDragActive] = useState(false);
   const computedCanSend = canSend ?? Boolean(value.trim());
+  const slash = useSlashCommand(value);
 
   const MODEL_OPTIONS: { value: ChatModelPreference; label: string; tooltip: string }[] = [
     { value: 'fast', label: MODEL_LABELS.fast, tooltip: '响应最快，适合简单问题' },
@@ -109,7 +112,48 @@ export default function ChatInput({
     }
   }, [autoFocus]);
 
+  const handleSlashSelect = useCallback(
+    (item: Parameters<typeof SlashCommandMenu>[0]['items'][number]) => {
+      if (item.prefillPrompt) {
+        onChange(item.prefillPrompt);
+      } else {
+        onChange(`/${item.name} `);
+      }
+      textareaRef.current?.focus();
+    },
+    [onChange],
+  );
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Skip during IME composition (e.g. pinyin input)
+    if (e.nativeEvent.isComposing) return;
+
+    if (slash.isOpen) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        slash.dismiss();
+        return;
+      }
+      if (slash.items.length > 0) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          slash.moveSelection(1);
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          slash.moveSelection(-1);
+          return;
+        }
+        if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+          e.preventDefault();
+          const selected = slash.getSelectedItem();
+          if (selected) handleSlashSelect(selected);
+          return;
+        }
+      }
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       if (!isLoading && computedCanSend) {
@@ -274,6 +318,17 @@ export default function ChatInput({
 
           {attachmentError && (
             <p className="px-3 pb-2 text-xs text-red-600 dark:text-red-400">{attachmentError}</p>
+          )}
+
+          {slash.isOpen && (
+            <div className="px-1 pb-1">
+              <SlashCommandMenu
+                items={slash.items}
+                selectedIndex={slash.selectedIndex}
+                onSelect={handleSlashSelect}
+                onHover={slash.setSelectedIndex}
+              />
+            </div>
           )}
 
           <textarea

--- a/src/renderer/components/SlashCommandMenu.tsx
+++ b/src/renderer/components/SlashCommandMenu.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+
+import type { SlashCommandItem } from '@/hooks/useSlashCommand';
+
+interface SlashCommandMenuProps {
+  items: SlashCommandItem[];
+  selectedIndex: number;
+  onSelect: (item: SlashCommandItem) => void;
+  onHover: (index: number) => void;
+}
+
+export default function SlashCommandMenu({
+  items,
+  selectedIndex,
+  onSelect,
+  onHover,
+}: SlashCommandMenuProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-xl border border-neutral-200/80 bg-white/95 p-3 shadow-lg backdrop-blur-xl dark:border-neutral-700/70 dark:bg-neutral-900/95">
+        <p className="text-xs text-neutral-400 dark:text-neutral-500">
+          没有匹配的技能
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={listRef}
+      className="max-h-60 overflow-y-auto rounded-xl border border-neutral-200/80 bg-white/95 shadow-lg backdrop-blur-xl dark:border-neutral-700/70 dark:bg-neutral-900/95"
+    >
+      {items.map((item, index) => (
+        <button
+          key={item.id}
+          ref={index === selectedIndex ? selectedRef : undefined}
+          onMouseDown={(e) => {
+            e.preventDefault(); // Prevent textarea blur
+            onSelect(item);
+          }}
+          onMouseEnter={() => onHover(index)}
+          className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left transition-colors ${
+            index === selectedIndex
+              ? 'bg-neutral-100 dark:bg-neutral-800'
+              : 'hover:bg-neutral-50 dark:hover:bg-neutral-800/50'
+          }`}
+        >
+          <span className="text-sm font-medium text-neutral-800 dark:text-neutral-200">
+            /{item.name}
+            {item.displayName !== item.name && (
+              <span className="ml-1.5 text-xs font-normal text-neutral-500 dark:text-neutral-400">
+                {item.displayName}
+              </span>
+            )}
+          </span>
+          {item.description && (
+            <span className="line-clamp-1 text-xs text-neutral-400 dark:text-neutral-500">
+              {item.description}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/hooks/useSlashCommand.ts
+++ b/src/renderer/hooks/useSlashCommand.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { skillCards } from '@/constants/skillCards';
+
+import type { SkillInfo } from '../electron';
+
+export interface SlashCommandItem {
+  id: string;
+  name: string;
+  displayName: string;
+  description: string;
+  /** If set, selecting this item replaces the entire input with this prompt */
+  prefillPrompt: string | null;
+}
+
+function buildSlashItems(installedSkills: SkillInfo[]): SlashCommandItem[] {
+  const items: SlashCommandItem[] = [];
+  const seen = new Set<string>();
+
+  // Skill cards first (they have friendly Chinese titles and prefill prompts)
+  for (const card of skillCards) {
+    if (!card.prefillPrompt) continue;
+    seen.add(card.id);
+    items.push({
+      id: `card-${card.id}`,
+      name: card.id,
+      displayName: card.title,
+      description: card.example,
+      prefillPrompt: card.prefillPrompt,
+    });
+  }
+
+  // Installed skills not already covered by cards
+  for (const skill of installedSkills) {
+    if (seen.has(skill.name)) continue;
+    items.push({
+      id: `skill-${skill.name}`,
+      name: skill.name,
+      displayName: skill.name,
+      description: skill.manifest?.description ?? '',
+      prefillPrompt: null,
+    });
+  }
+
+  return items;
+}
+
+export function useSlashCommand(inputValue: string) {
+  const [installedSkills, setInstalledSkills] = useState<SkillInfo[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+
+  // Fetch installed skills on mount and when skills page might have changed
+  useEffect(() => {
+    window.electron.skill
+      .list()
+      .then(({ skills }) => setInstalledSkills(skills))
+      .catch(() => {});
+  }, []);
+
+  const allItems = useMemo(() => buildSlashItems(installedSkills), [installedSkills]);
+
+  // Detect slash command pattern: input starts with "/" and no whitespace
+  const slashMatch = useMemo(() => {
+    if (!inputValue.startsWith('/')) return null;
+    // Close menu if any whitespace appears (space, newline, tab)
+    if (/\s/.test(inputValue)) return null;
+    return inputValue.slice(1).toLowerCase();
+  }, [inputValue]);
+
+  const isOpen = slashMatch !== null && !dismissed;
+
+  // Reset dismissed state and refresh skills when slash match changes
+  const prevSlashMatchRef = useRef(slashMatch);
+  if (prevSlashMatchRef.current !== slashMatch) {
+    prevSlashMatchRef.current = slashMatch;
+    setSelectedIndex(0);
+    setDismissed(false);
+    // Refresh skill list when user starts a new slash command
+    if (slashMatch === '') {
+      window.electron.skill
+        .list()
+        .then(({ skills }) => setInstalledSkills(skills))
+        .catch(() => {});
+    }
+  }
+
+  const filtered = useMemo(() => {
+    if (slashMatch === null) return [];
+    if (slashMatch === '') return allItems;
+    return allItems.filter(
+      (item) =>
+        item.name.toLowerCase().includes(slashMatch) ||
+        item.displayName.toLowerCase().includes(slashMatch) ||
+        item.description.toLowerCase().includes(slashMatch),
+    );
+  }, [slashMatch, allItems]);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  const refreshSkills = useCallback(() => {
+    window.electron.skill
+      .list()
+      .then(({ skills }) => setInstalledSkills(skills))
+      .catch(() => {});
+  }, []);
+
+  const moveSelection = useCallback(
+    (delta: number) => {
+      if (filtered.length === 0) return;
+      setSelectedIndex((prev) => {
+        const next = prev + delta;
+        if (next < 0) return filtered.length - 1;
+        if (next >= filtered.length) return 0;
+        return next;
+      });
+    },
+    [filtered.length],
+  );
+
+  const getSelectedItem = useCallback((): SlashCommandItem | null => {
+    return filtered[selectedIndex] ?? null;
+  }, [filtered, selectedIndex]);
+
+  return {
+    isOpen,
+    items: filtered,
+    selectedIndex,
+    setSelectedIndex,
+    moveSelection,
+    getSelectedItem,
+    dismiss,
+    refreshSkills,
+  };
+}


### PR DESCRIPTION
## Summary
- 输入 `/` 时弹出技能自动补全菜单，支持按名称、标题、描述过滤
- 键盘操作：上下箭头导航、Tab/Enter 选中、Escape 关闭（不清空输入）
- 处理 IME 输入法 composing 状态，避免中文输入干扰
- 每次触发 `/` 时刷新技能列表，确保新安装的技能可见

## Test plan
- [ ] 输入 `/` 验证弹出所有技能列表
- [ ] 输入 `/pd` 验证过滤出 pdf 相关技能
- [ ] 上下箭头导航并 Enter 选中
- [ ] Escape 关闭菜单但保留输入内容
- [ ] 使用中文输入法时不会误触发选择
- [ ] 空格或换行后菜单自动关闭
- [ ] 安装新技能后重新输入 `/` 可以看到

🤖 Generated with [Claude Code](https://claude.com/claude-code)