### PR TITLE
chore: add PostHog API key for analytics

### DIFF
--- a/src/main/lib/analytics-service.ts
+++ b/src/main/lib/analytics-service.ts
@@ -9,8 +9,7 @@ import type {
 } from '../../shared/types/analytics';
 import { loadConfig, saveConfig } from './config';
 
-// TODO: 替换为实际的 PostHog 项目 API Key，当前为占位值
-const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY ?? 'phc_PLACEHOLDER';
+const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY ?? 'phc_edveghHyU8AI3VDiJdA1UgTc5BFgiCQU0tGbtuIoIET';
 // 使用 EU 端点，中国大陆访问更稳定
 const POSTHOG_HOST = process.env.POSTHOG_HOST ?? 'https://eu.i.posthog.com';
 


### PR DESCRIPTION
## Summary
- 将 PostHog API key 从占位值替换为真实的 EU Cloud 项目 key
- 项目 ID: 137774，区域: EU Cloud

## Test plan
- [ ] 启动应用，在设置中开启"发送匿名使用统计"
- [ ] 执行几个操作（发消息、切换模型等），确认 PostHog 后台收到事件

🤖 Generated with [Claude Code](https://claude.com/claude-code)