### PR TITLE
fix: align tab highlighting, skip code preview, handle absolute paths

### DIFF
--- a/src/main/handlers/workspace-handlers.ts
+++ b/src/main/handlers/workspace-handlers.ts
@@ -1,6 +1,6 @@
 import { watch, type FSWatcher } from 'fs';
 import { readdir, readFile, rm, stat } from 'fs/promises';
-import { join, relative, resolve, sep } from 'path';
+import { isAbsolute, join, relative, resolve, sep } from 'path';
 import { ipcMain, shell, type BrowserWindow } from 'electron';
 
 import { ALL_TEXT_EXTENSIONS, MAX_PREVIEW_FILE_SIZE } from '../../shared/file-extensions';
@@ -177,7 +177,8 @@ export function registerWorkspaceHandlers(getMainWindow: () => BrowserWindow | n
 
   ipcMain.handle('workspace:read-file', async (_event, relativePath: string) => {
     const workspaceDir = getWorkspaceDir();
-    const fullPath = resolve(join(workspaceDir, relativePath));
+    // Handle both absolute and relative paths
+    const fullPath = isAbsolute(relativePath) ? resolve(relativePath) : resolve(join(workspaceDir, relativePath));
 
     // Security: prevent path traversal
     if (!isWithinWorkspace(fullPath, workspaceDir)) {
@@ -213,7 +214,7 @@ export function registerWorkspaceHandlers(getMainWindow: () => BrowserWindow | n
     'workspace:delete-file',
     async (_event, relativePath: string, isDirectory: boolean) => {
       const workspaceDir = getWorkspaceDir();
-      const fullPath = resolve(join(workspaceDir, relativePath));
+      const fullPath = isAbsolute(relativePath) ? resolve(relativePath) : resolve(join(workspaceDir, relativePath));
 
       if (!isWithinWorkspace(fullPath, workspaceDir)) {
         return { success: false, error: 'Path traversal not allowed' };
@@ -237,7 +238,7 @@ export function registerWorkspaceHandlers(getMainWindow: () => BrowserWindow | n
 
   ipcMain.handle('workspace:open-file', async (_event, relativePath: string) => {
     const workspaceDir = getWorkspaceDir();
-    const fullPath = resolve(join(workspaceDir, relativePath));
+    const fullPath = isAbsolute(relativePath) ? resolve(relativePath) : resolve(join(workspaceDir, relativePath));
 
     if (!isWithinWorkspace(fullPath, workspaceDir)) {
       return { success: false, error: 'Path traversal not allowed' };

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -472,19 +472,19 @@ export default function Sidebar({
         </div>
       </div>
 
-      {/* === Primary Action: 新建任务 === */}
-      <div className="shrink-0 px-3 pb-2">
+      {/* === Nav links === */}
+      <div className="shrink-0 space-y-0.5 px-3 pb-3">
         <button
           onClick={() => onNewChat()}
-          className="flex w-full items-center gap-2.5 rounded-xl bg-neutral-800 px-3 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-neutral-700 active:bg-neutral-900 dark:bg-neutral-200 dark:text-neutral-900 dark:hover:bg-neutral-300 dark:active:bg-neutral-100"
+          className={`flex w-full items-center gap-2.5 rounded-xl px-3 py-2 text-sm transition-colors ${
+            currentView === 'home' ?
+              'bg-white font-medium text-neutral-800 shadow-sm dark:bg-neutral-800 dark:text-neutral-100'
+            : 'text-neutral-600 hover:bg-neutral-200/70 dark:text-neutral-300 dark:hover:bg-neutral-800'
+          }`}
         >
           <SquarePen className="h-4 w-4" />
           新建任务
         </button>
-      </div>
-
-      {/* === Nav links === */}
-      <div className="shrink-0 space-y-0.5 px-3 pb-3">
         <button
           onClick={onSkillsClick}
           className={`flex w-full items-center gap-2.5 rounded-xl px-3 py-2 text-sm transition-colors ${

--- a/src/renderer/utils/artifacts.ts
+++ b/src/renderer/utils/artifacts.ts
@@ -28,7 +28,8 @@ export function extractArtifacts(messages: Message[]): Artifact[] {
       const ext = getFileExtension(input.file_path);
       const type = getArtifactType(ext);
 
-      if (!type) continue;
+      // Skip unsupported types and code files (auto-preview is distracting for code)
+      if (!type || type === 'code') continue;
 
       // Only inline content for HTML types (rendered in iframe)
       const inlineContent = type === 'html' ? input.content : undefined;


### PR DESCRIPTION
## 概述

修复三个 UI/逻辑问题：

1. **Tab 高亮一致性**：侧边栏「新建任务」按钮现在与「Skill 精选」和「定时任务」使用相同的条件高亮逻辑，仅在 home 视图时高亮
2. **代码文件自动预览**：Write 工具创建的 .js/.ts/.py 等代码文件不再自动触发右侧预览面板，减少编码时的干扰
3. **绝对路径处理**：workspace:read-file、workspace:open-file、workspace:delete-file 三个 handler 现在正确处理绝对和相对路径，修复了路径重复导致的 ENOENT 错误

## 技术细节

- `Sidebar.tsx`：移除固定背景样式，改用 `currentView === 'home'` 条件渲染
- `artifacts.ts`：增加 `type === 'code'` 过滤条件，与现有的 deliverables 逻辑对齐
- `workspace-handlers.ts`：引入 `isAbsolute()` 判断，绝对路径直接 resolve，相对路径才与工作目录拼接