### PR TITLE
fix: improve dark mode contrast in task progress panel and sync tools

### DIFF
--- a/scripts/buildSkills.js
+++ b/scripts/buildSkills.js
@@ -233,6 +233,21 @@ for (const skillName of skills) {
   }
 }
 
+// Copy .claude/tools/ directory (non-compiled TypeScript tools used by skills)
+const sourceToolsDir = join(sourceClaudeRoot, 'tools');
+const targetToolsDir = join(targetClaudeRoot, 'tools');
+if (existsSync(sourceToolsDir)) {
+  console.log('\nCopying .claude/tools/ directory...');
+  mkdirSync(targetToolsDir, { recursive: true });
+  const toolEntries = readdirSync(sourceToolsDir, { withFileTypes: true });
+  for (const entry of toolEntries) {
+    const sourcePath = join(sourceToolsDir, entry.name);
+    const targetPath = join(targetToolsDir, entry.name);
+    cpSync(sourcePath, targetPath, { recursive: true });
+    console.log(`  Copied tools/${entry.name}`);
+  }
+}
+
 // Clean up Bun build artifacts
 const bunBuildFiles = readdirSync(projectRoot).filter((f) => f.endsWith('.bun-build'));
 for (const file of bunBuildFiles) {

--- a/src/renderer/components/FloatingTaskPanel.tsx
+++ b/src/renderer/components/FloatingTaskPanel.tsx
@@ -50,7 +50,7 @@ export default function FloatingTaskPanel({ messages }: FloatingTaskPanelProps) 
 
   return (
     <div className="mx-auto w-full max-w-2xl px-2">
-      <div className="dark:bg-neutral-850/90 rounded-2xl border border-neutral-200/60 bg-white/95 shadow-lg shadow-black/5 backdrop-blur-xl dark:border-neutral-700/50 dark:shadow-black/30">
+      <div className="rounded-2xl border border-neutral-200/60 bg-white/95 shadow-lg shadow-black/5 backdrop-blur-xl dark:border-neutral-600/50 dark:bg-neutral-800/95 dark:shadow-black/30">
         {/* Header */}
         <button
           type="button"
@@ -62,7 +62,7 @@ export default function FloatingTaskPanel({ messages }: FloatingTaskPanelProps) 
             <span className="text-sm font-medium text-neutral-700 dark:text-neutral-200">
               任务进度
             </span>
-            <span className="text-xs text-neutral-400 dark:text-neutral-500">
+            <span className="text-xs text-neutral-400 dark:text-neutral-400">
               {completedCount}/{totalCount}
             </span>
           </div>
@@ -75,14 +75,14 @@ export default function FloatingTaskPanel({ messages }: FloatingTaskPanelProps) 
               />
             </div>
             {isCollapsed ?
-              <ChevronDown className="size-3.5 text-neutral-400 dark:text-neutral-500" />
-            : <ChevronUp className="size-3.5 text-neutral-400 dark:text-neutral-500" />}
+              <ChevronDown className="size-3.5 text-neutral-400 dark:text-neutral-400" />
+            : <ChevronUp className="size-3.5 text-neutral-400 dark:text-neutral-400" />}
           </div>
         </button>
 
         {/* Task list */}
         {!isCollapsed && (
-          <div className="border-t border-neutral-100 px-4 pt-1.5 pb-3 dark:border-neutral-800">
+          <div className="border-t border-neutral-100 px-4 pt-1.5 pb-3 dark:border-neutral-700">
             <div className="space-y-1">
               {todos.map((todo, index) => (
                 <div key={index} className="flex items-start gap-2 py-0.5">
@@ -96,9 +96,9 @@ export default function FloatingTaskPanel({ messages }: FloatingTaskPanelProps) 
                   <span
                     className={`text-sm leading-snug ${
                       todo.status === 'completed' ?
-                        'text-neutral-400 line-through dark:text-neutral-500'
+                        'text-neutral-400 line-through dark:text-neutral-400'
                       : todo.status === 'in_progress' ? 'text-neutral-700 dark:text-neutral-200'
-                      : 'text-neutral-500 dark:text-neutral-400'
+                      : 'text-neutral-500 dark:text-neutral-300'
                     }`}
                   >
                     {todo.content}


### PR DESCRIPTION
## 概述
修复任务进度面板在暗色模式下的可读性问题，以及 web-app skill 构建时缺失 crud.ts 工具的问题。

## 变更内容
- **UI**: 提亮暗色模式下的任务进度文本颜色，调整容器背景和分隔线颜色以避免混淆
- **构建**: 修复 buildSkills.js，将 .claude/tools/ 目录复制到 out/.claude/tools/，确保 workspace 同步时包含 crud.ts 工具

## 测试
- lint ✓
- typecheck ✓  
- tests ✓ (75 passed)
- adversarial review (Skeptic lens) 完成

🤖 Generated with Claude Code