### PR TITLE
fix: reduce UI lag when switching sessions

### DIFF
--- a/src/main/lib/claude-session.ts
+++ b/src/main/lib/claude-session.ts
@@ -80,6 +80,7 @@ let isInterruptingResponse = false;
 // Map stream index to tool ID for current message
 const streamIndexToToolId: Map<number, string> = new Map();
 let pendingResumeSessionId: string | null = null;
+let sessionGeneration = 0;
 
 export function getModelIdForPreference(
   preference: ChatModelPreference = currentModelPreference
@@ -152,6 +153,9 @@ export async function interruptCurrentResponse(mainWindow: BrowserWindow | null)
 }
 
 export async function resetSession(resumeSessionId?: string | null): Promise<void> {
+  // Increment generation to invalidate any zombie session's IPC emissions
+  sessionGeneration++;
+
   // Signal any running session to abort
   shouldAbortSession = true;
 
@@ -165,9 +169,12 @@ export async function resetSession(resumeSessionId?: string | null): Promise<voi
   regenerateSessionId(resumeSessionId ?? null);
   pendingResumeSessionId = resumeSessionId ?? null;
 
-  // Wait for the current session to fully terminate before proceeding
+  // Wait for the current session to fully terminate (with 3s timeout to avoid UI hang)
   if (sessionTerminationPromise) {
-    await sessionTerminationPromise;
+    await Promise.race([
+      sessionTerminationPromise,
+      new Promise<void>((resolve) => setTimeout(resolve, 3000))
+    ]);
   }
 
   // Clear session state
@@ -198,6 +205,8 @@ export async function startStreamingSession(mainWindow: BrowserWindow | null): P
   isProcessing = true;
   // Clear stream index mapping for new session
   streamIndexToToolId.clear();
+  // Capture generation so zombie sessions (from timeout) can't emit events
+  const myGeneration = sessionGeneration;
 
   // Create a promise that resolves when this session terminates
   let resolveTermination: () => void;
@@ -272,8 +281,8 @@ export async function startStreamingSession(mainWindow: BrowserWindow | null): P
 
     // Process streaming responses
     for await (const sdkMessage of querySession) {
-      // Check if session should be aborted
-      if (shouldAbortSession) {
+      // Check if session should be aborted or has been superseded by a newer session
+      if (shouldAbortSession || myGeneration !== sessionGeneration) {
         break;
       }
 

--- a/src/main/lib/conversation-db.ts
+++ b/src/main/lib/conversation-db.ts
@@ -12,6 +12,11 @@ export interface Conversation {
   projectId?: string | null;
 }
 
+/** Lightweight version returned by listConversations — no full messages payload */
+export interface ConversationSummary extends Omit<Conversation, 'messages'> {
+  preview: string;
+}
+
 interface ConversationFile {
   id: string;
   title: string;
@@ -146,7 +151,48 @@ export function getConversation(id: string): Conversation | null {
   };
 }
 
-export function listConversations(limit: number = 100): Conversation[] {
+function truncatePreview(text: string, maxLength: number): string {
+  return text.length > maxLength ? text.slice(0, maxLength).trim() + '...' : text;
+}
+
+function extractTextFromContent(content: unknown, maxLength: number): string | null {
+  if (typeof content === 'string') {
+    return truncatePreview(content, maxLength);
+  }
+  if (Array.isArray(content)) {
+    for (let j = content.length - 1; j >= 0; j--) {
+      const block = content[j];
+      if (
+        typeof block === 'object' &&
+        block !== null &&
+        'type' in block &&
+        block.type === 'text' &&
+        'text' in block &&
+        typeof block.text === 'string'
+      ) {
+        return truncatePreview(block.text as string, maxLength);
+      }
+    }
+  }
+  return null;
+}
+
+function extractPreview(messages: unknown[], maxLength: number = 90): string {
+  // Try last assistant message first, then fall back to last user message
+  for (const targetRole of ['assistant', 'user']) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (typeof msg !== 'object' || msg === null || !('role' in msg)) continue;
+      if ((msg as { role: string }).role !== targetRole) continue;
+
+      const text = extractTextFromContent((msg as { content?: unknown }).content, maxLength);
+      if (text) return text;
+    }
+  }
+  return '';
+}
+
+export function listConversations(limit: number = 100): ConversationSummary[] {
   const dir = getConversationsDir();
   const files = readdirSync(dir)
     .filter((file) => file.endsWith('.json'))
@@ -172,7 +218,7 @@ export function listConversations(limit: number = 100): Conversation[] {
   return files.map(({ conversationFile }) => ({
     id: conversationFile.id,
     title: conversationFile.title,
-    messages: JSON.stringify(conversationFile.messages),
+    preview: extractPreview(conversationFile.messages),
     createdAt: conversationFile.createdAt,
     updatedAt: conversationFile.updatedAt,
     sessionId: conversationFile.sessionId ?? null,

--- a/src/renderer/components/ChatHistoryDrawer.tsx
+++ b/src/renderer/components/ChatHistoryDrawer.tsx
@@ -1,14 +1,7 @@
 import { Clock, MessageSquare, Plus, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { Conversation } from '@/electron';
-
-const truncateText = (text: string, maxLength: number = 90) => {
-  if (text.length <= maxLength) {
-    return text;
-  }
-  return `${text.slice(0, maxLength).trim()}...`;
-};
+import type { ConversationSummary } from '@/electron';
 
 interface ChatHistoryDrawerProps {
   isOpen: boolean;
@@ -25,7 +18,7 @@ export default function ChatHistoryDrawer({
   currentConversationId,
   onNewChat
 }: ChatHistoryDrawerProps) {
-  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const relativeTimeFormatter = useMemo(
     () =>
@@ -80,41 +73,9 @@ export default function ChatHistoryDrawer({
   };
 
   const conversationPreviews = useMemo(() => {
-    return conversations.reduce<Record<string, string>>((acc, conversation) => {
-      try {
-        const parsed = JSON.parse(conversation.messages) as Array<{
-          role: string;
-          content: string | { type: string; text?: string }[];
-        }>;
-        // Find the last user message (iterate in reverse)
-        let lastUserMessage: (typeof parsed)[0] | undefined;
-        for (let i = parsed.length - 1; i >= 0; i--) {
-          if (parsed[i].role === 'user') {
-            lastUserMessage = parsed[i];
-            break;
-          }
-        }
-        if (lastUserMessage) {
-          if (typeof lastUserMessage.content === 'string') {
-            acc[conversation.id] = truncateText(lastUserMessage.content);
-          } else if (Array.isArray(lastUserMessage.content)) {
-            const textBlock = lastUserMessage.content.find(
-              (block) => typeof block === 'object' && block !== null && 'text' in block
-            );
-            if (textBlock && typeof textBlock === 'object' && textBlock !== null) {
-              acc[conversation.id] =
-                'text' in textBlock && typeof textBlock.text === 'string' ?
-                  truncateText(textBlock.text)
-                : '';
-            }
-          }
-        }
-      } catch {
-        acc[conversation.id] = '';
-      }
-      acc[conversation.id] = acc[conversation.id] || '点击继续之前的对话';
-      return acc;
-    }, {});
+    return Object.fromEntries(
+      conversations.map((c) => [c.id, c.preview || '点击继续之前的对话'])
+    );
   }, [conversations]);
 
   const formatRelativeDate = useCallback(

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -18,7 +18,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import type { Conversation, Project, ScheduledTask } from '@/electron';
+import type { ConversationSummary, Project, ScheduledTask } from '@/electron';
 
 import {
   AlertDialog,
@@ -28,11 +28,6 @@ import {
   AlertDialogFooter,
   AlertDialogTitle
 } from './ui/alert-dialog';
-
-const truncateText = (text: string, maxLength: number = 60) => {
-  if (text.length <= maxLength) return text;
-  return `${text.slice(0, maxLength).trim()}...`;
-};
 
 type View = 'home' | 'settings' | 'skills' | 'schedules' | 'db-viewer';
 
@@ -61,7 +56,7 @@ export default function Sidebar({
   selectedProjectId,
   onSelectProject
 }: SidebarProps) {
-  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
   const [scheduledTasks, setScheduledTasks] = useState<ScheduledTask[]>([]);
   const [isSchedulesCollapsed, setIsSchedulesCollapsed] = useState(() => {
@@ -110,6 +105,17 @@ export default function Sidebar({
     []
   );
 
+  const loadConversations = useCallback(async () => {
+    try {
+      const response = await window.electron.conversation.list();
+      if (response.success && response.conversations) {
+        setConversations(response.conversations);
+      }
+    } catch (error) {
+      console.error('Error loading conversations:', error);
+    }
+  }, []);
+
   const loadData = useCallback(async () => {
     setIsLoading(true);
     try {
@@ -138,9 +144,14 @@ export default function Sidebar({
     loadData();
   }, [loadData]);
 
+  const prevConversationIdRef = useRef(currentConversationId);
   useEffect(() => {
-    if (currentConversationId) loadData();
-  }, [currentConversationId, loadData]);
+    // Refresh conversation list when the active conversation changes (including to null)
+    if (prevConversationIdRef.current !== currentConversationId) {
+      prevConversationIdRef.current = currentConversationId;
+      loadConversations();
+    }
+  }, [currentConversationId, loadConversations]);
 
   // Auto-select default project on first load
   useEffect(() => {
@@ -272,46 +283,9 @@ export default function Sidebar({
   };
 
   const conversationPreviews = useMemo(() => {
-    return conversations.reduce<Record<string, string>>((acc, conversation) => {
-      try {
-        const parsed = JSON.parse(conversation.messages) as Array<{
-          role: string;
-          content: string | { type: string; text?: string }[];
-        }>;
-        let preview = '';
-        for (let i = parsed.length - 1; i >= 0; i--) {
-          if (parsed[i].role !== 'assistant') continue;
-          const content = parsed[i].content;
-          if (typeof content === 'string') {
-            preview = truncateText(content);
-            break;
-          }
-          if (Array.isArray(content)) {
-            const textBlock = content.findLast(
-              (block) =>
-                typeof block === 'object' &&
-                block !== null &&
-                block.type === 'text' &&
-                'text' in block
-            );
-            if (
-              textBlock &&
-              typeof textBlock === 'object' &&
-              'text' in textBlock &&
-              typeof textBlock.text === 'string'
-            ) {
-              preview = truncateText(textBlock.text);
-              break;
-            }
-          }
-        }
-        acc[conversation.id] = preview;
-      } catch {
-        acc[conversation.id] = '';
-      }
-      acc[conversation.id] = acc[conversation.id] || '继续任务...';
-      return acc;
-    }, {});
+    return Object.fromEntries(
+      conversations.map((c) => [c.id, c.preview || '继续任务...'])
+    );
   }, [conversations]);
 
   const formatRelativeDate = useCallback(
@@ -354,7 +328,7 @@ export default function Sidebar({
   );
 
   const grouped = useMemo(() => {
-    const result: Record<string, Conversation[]> = {};
+    const result: Record<string, ConversationSummary[]> = {};
     for (const conv of conversations) {
       if (conv.projectId && projectIds.has(conv.projectId)) {
         if (!result[conv.projectId]) result[conv.projectId] = [];
@@ -390,7 +364,7 @@ export default function Sidebar({
   );
 
 
-  const renderConversationItem = (conversation: Conversation) => {
+  const renderConversationItem = (conversation: ConversationSummary) => {
     const isActive = conversation.id === currentConversationId;
     return (
       <div

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -180,6 +180,11 @@ export interface Conversation {
   projectId?: string | null;
 }
 
+/** Lightweight version returned by conversation:list — no full messages payload */
+export interface ConversationSummary extends Omit<Conversation, 'messages'> {
+  preview: string;
+}
+
 export interface Project {
   id: string;
   name: string;
@@ -210,7 +215,7 @@ export interface ProjectUpdateResponse {
 
 export interface ConversationListResponse {
   success: boolean;
-  conversations?: Conversation[];
+  conversations?: ConversationSummary[];
   error?: string;
 }
 

--- a/src/renderer/pages/Chat.tsx
+++ b/src/renderer/pages/Chat.tsx
@@ -432,18 +432,12 @@ const Chat = forwardRef<ChatHandle, ChatProps>(function Chat(
     clearPendingAttachments();
 
     try {
+      // Fire-and-forget: save current conversation without blocking the switch
       if (currentConversationId && messages.length > 0) {
-        try {
-          const messagesToSave = serializeMessagesForStorage(messages);
-          await window.electron.conversation.update(
-            currentConversationId,
-            undefined,
-            messagesToSave,
-            currentSessionId ?? undefined
-          );
-        } catch (error) {
-          console.error('Error saving conversation before new chat:', error);
-        }
+        const messagesToSave = serializeMessagesForStorage(messages);
+        window.electron.conversation
+          .update(currentConversationId, undefined, messagesToSave, currentSessionId ?? undefined)
+          .catch((error) => console.error('Error saving conversation before new chat:', error));
       }
 
       await window.electron.chat.resetSession();
@@ -465,18 +459,14 @@ const Chat = forwardRef<ChatHandle, ChatProps>(function Chat(
     clearPendingAttachments();
 
     try {
+      // Fire-and-forget: save current conversation without blocking the switch
       if (currentConversationId && messages.length > 0) {
-        try {
-          const messagesToSave = serializeMessagesForStorage(messages);
-          await window.electron.conversation.update(
-            currentConversationId,
-            undefined,
-            messagesToSave,
-            currentSessionId ?? undefined
+        const messagesToSave = serializeMessagesForStorage(messages);
+        window.electron.conversation
+          .update(currentConversationId, undefined, messagesToSave, currentSessionId ?? undefined)
+          .catch((error) =>
+            console.error('Error saving conversation before switching:', error)
           );
-        } catch (error) {
-          console.error('Error saving conversation before switching:', error);
-        }
       }
 
       const response = await window.electron.conversation.get(conversationId);


### PR DESCRIPTION
## Summary
- **IPC 瘦身**: `listConversations` 不再返回完整 messages，改为返回 `ConversationSummary` 类型（含 preview 字段），预览在主进程提取
- **消除渲染端重解析**: Sidebar 和 ChatHistoryDrawer 不再对所有对话做 `JSON.parse` + 遍历，直接用服务端 preview
- **非阻塞保存**: 切换对话前的保存改为 fire-and-forget，不再阻塞 UI
- **Session 超时 + 防僵尸**: `resetSession` 加 3s 超时；新增 `sessionGeneration` 计数器防止旧 session 泄漏事件到新对话
- **轻量刷新**: `currentConversationId` 变化时只刷新对话列表，不重新加载 projects/schedules

## Test plan
- [ ] 在有多个对话的情况下，点击"新建任务"验证无明显卡顿
- [ ] 点击"开发"按钮验证响应速度
- [ ] 点击"让小马修复"按钮验证响应速度
- [ ] 切换不同对话验证 sidebar 列表正确更新
- [ ] 验证对话预览文本正确显示（assistant 回复优先，fallback 到 user 消息）
- [ ] 验证新建对话后 sidebar 正确刷新

🤖 Generated with [Claude Code](https://claude.com/claude-code)