### PR TITLE
feat: replace drizzle-kit with bun:sqlite schema push

### DIFF
--- a/.claude/skills/web-app/SKILL.md
+++ b/.claude/skills/web-app/SKILL.md
@@ -108,8 +108,8 @@ Change the `<title>` tag to match your app name.
 
 ## What NOT to Do
 
-- Do NOT create `package.json`, `vite.config.ts`, `tsconfig.json`, `drizzle.config.ts` — these are created by `crud init`
-- Do NOT create `src/main.tsx`, `src/index.css`, `src/db/index.ts`, `src/server/index.ts` — these are managed by the CLI
+- Do NOT create `package.json`, `vite.config.ts`, `tsconfig.json` — these are created by `crud init`
+- Do NOT create `src/main.tsx`, `src/index.css`, `src/db/index.ts`, `src/db/push.ts`, `src/server/index.ts` — these are managed by the CLI
 - Do NOT modify files in `src/server/index.ts` imports section (the `// [crud:imports]` and `// [crud:routes]` markers are used by the CLI)
 
 ## Available Libraries
@@ -127,7 +127,7 @@ These are pre-installed and can be imported:
 Tell the user:
 
 - The app files have been generated
-- They can find the app card in the sidebar under "My Apps"
-- Click **"Dev"** to start the development server with hot reload
-- Click **"Build & Publish"** or **"Publish"** to build for production and share via LAN
+- They can点击聊天页面右上角的 🌐 图标，在下拉面板中找到该应用
+- Click **"开发"** to start the development server with hot reload
+- Click **"构建并发布"** or **"发布"** to build for production and share via LAN
 - Share the generated LAN URL with colleagues

--- a/.claude/tools/crud.ts
+++ b/.claude/tools/crud.ts
@@ -89,7 +89,7 @@ function init(appId: string): void {
           'dev:server': 'bun --hot run src/server/index.ts',
           'dev:client': 'vite',
           build: 'vite build',
-          'db:push': 'bunx drizzle-kit push',
+          'db:push': 'bun run src/db/push.ts',
         },
         dependencies: {
           react: '^19.2.0',
@@ -106,7 +106,6 @@ function init(appId: string): void {
           '@tailwindcss/vite': '^4.1.17',
           typescript: '^5.9.3',
           vite: '^7.1.12',
-          'drizzle-kit': '^0.31.9',
           '@types/bun': 'latest',
         },
       },
@@ -131,22 +130,6 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
-  },
-})
-`
-  )
-
-  // drizzle.config.ts
-  writeFileSync(
-    join(appDir, 'drizzle.config.ts'),
-    `import { defineConfig } from 'drizzle-kit'
-
-export default defineConfig({
-  dialect: 'sqlite',
-  schema: './src/db/schema.ts',
-  out: './drizzle',
-  dbCredentials: {
-    url: './data.sqlite',
   },
 })
 `
@@ -242,6 +225,78 @@ createRoot(document.getElementById('root')!).render(
     `import { drizzle } from 'drizzle-orm/bun-sqlite'
 
 export const db = drizzle('./data.sqlite')
+`
+  )
+
+  // src/db/push.ts — schema push using bun:sqlite (replaces drizzle-kit push)
+  writeFileSync(
+    join(appDir, 'src', 'db', 'push.ts'),
+    `import { Database } from 'bun:sqlite'
+import { getTableConfig, type SQLiteColumn } from 'drizzle-orm/sqlite-core'
+
+import * as schema from './schema'
+
+function serializeDefault(col: SQLiteColumn): string {
+  const d = col.default
+  if (d === undefined || d === null) return ''
+  if (typeof d === 'object' && 'queryChunks' in d) {
+    const sql = (d as { queryChunks: { value: string[] }[] }).queryChunks
+      .map((c) => c.value.join(''))
+      .join('')
+    return \` DEFAULT \${sql}\`
+  }
+  if (typeof d === 'string') return \` DEFAULT '\${d.replace(/'/g, "''")}'\`
+  return \` DEFAULT \${d}\`
+}
+
+function colDef(col: SQLiteColumn, forAlter = false): string {
+  let def = \`"\${col.name}" \${col.getSQLType()}\`
+  if (col.primary) {
+    def += ' PRIMARY KEY'
+    if ((col as unknown as { autoIncrement: boolean }).autoIncrement) def += ' AUTOINCREMENT'
+  }
+  // SQLite ALTER TABLE ADD COLUMN rejects NOT NULL without a default
+  if (col.notNull && !col.primary && !(forAlter && !col.hasDefault)) def += ' NOT NULL'
+  if (col.hasDefault) def += serializeDefault(col)
+  return def
+}
+
+const db = new Database('./data.sqlite')
+db.run('BEGIN')
+try {
+  for (const value of Object.values(schema)) {
+    if (!value || typeof value !== 'object') continue
+    let config
+    try {
+      config = getTableConfig(value as Parameters<typeof getTableConfig>[0])
+    } catch {
+      continue
+    }
+    const exists = db
+      .query(\`SELECT name FROM sqlite_master WHERE type='table' AND name=?\`)
+      .get(config.name)
+    if (!exists) {
+      const cols = config.columns.map((c) => colDef(c)).join(', ')
+      db.run(\`CREATE TABLE "\${config.name}" (\${cols})\`)
+      console.log(\`Created table: \${config.name}\`)
+    } else {
+      const existing = db.query(\`PRAGMA table_info("\${config.name}")\`).all() as { name: string }[]
+      const existingNames = new Set(existing.map((c) => c.name))
+      for (const col of config.columns) {
+        if (!existingNames.has(col.name)) {
+          db.run(\`ALTER TABLE "\${config.name}" ADD COLUMN \${colDef(col, true)}\`)
+          console.log(\`Added column: \${config.name}.\${col.name}\`)
+        }
+      }
+    }
+  }
+  db.run('COMMIT')
+} catch (e) {
+  db.run('ROLLBACK')
+  throw e
+}
+
+console.log('Schema push complete.')
 `
   )
 

--- a/resources/crud-cli/crud.ts
+++ b/resources/crud-cli/crud.ts
@@ -89,7 +89,7 @@ function init(appId: string): void {
           'dev:server': 'bun --hot run src/server/index.ts',
           'dev:client': 'vite',
           build: 'vite build',
-          'db:push': 'bunx drizzle-kit push',
+          'db:push': 'bun run src/db/push.ts',
         },
         dependencies: {
           react: '^19.2.0',
@@ -106,7 +106,6 @@ function init(appId: string): void {
           '@tailwindcss/vite': '^4.1.17',
           typescript: '^5.9.3',
           vite: '^7.1.12',
-          'drizzle-kit': '^0.31.9',
           '@types/bun': 'latest',
         },
       },
@@ -131,22 +130,6 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
-  },
-})
-`
-  )
-
-  // drizzle.config.ts
-  writeFileSync(
-    join(appDir, 'drizzle.config.ts'),
-    `import { defineConfig } from 'drizzle-kit'
-
-export default defineConfig({
-  dialect: 'sqlite',
-  schema: './src/db/schema.ts',
-  out: './drizzle',
-  dbCredentials: {
-    url: './data.sqlite',
   },
 })
 `
@@ -242,6 +225,78 @@ createRoot(document.getElementById('root')!).render(
     `import { drizzle } from 'drizzle-orm/bun-sqlite'
 
 export const db = drizzle('./data.sqlite')
+`
+  )
+
+  // src/db/push.ts — schema push using bun:sqlite (replaces drizzle-kit push)
+  writeFileSync(
+    join(appDir, 'src', 'db', 'push.ts'),
+    `import { Database } from 'bun:sqlite'
+import { getTableConfig, type SQLiteColumn } from 'drizzle-orm/sqlite-core'
+
+import * as schema from './schema'
+
+function serializeDefault(col: SQLiteColumn): string {
+  const d = col.default
+  if (d === undefined || d === null) return ''
+  if (typeof d === 'object' && 'queryChunks' in d) {
+    const sql = (d as { queryChunks: { value: string[] }[] }).queryChunks
+      .map((c) => c.value.join(''))
+      .join('')
+    return \` DEFAULT \${sql}\`
+  }
+  if (typeof d === 'string') return \` DEFAULT '\${d.replace(/'/g, "''")}'\`
+  return \` DEFAULT \${d}\`
+}
+
+function colDef(col: SQLiteColumn, forAlter = false): string {
+  let def = \`"\${col.name}" \${col.getSQLType()}\`
+  if (col.primary) {
+    def += ' PRIMARY KEY'
+    if ((col as unknown as { autoIncrement: boolean }).autoIncrement) def += ' AUTOINCREMENT'
+  }
+  // SQLite ALTER TABLE ADD COLUMN rejects NOT NULL without a default
+  if (col.notNull && !col.primary && !(forAlter && !col.hasDefault)) def += ' NOT NULL'
+  if (col.hasDefault) def += serializeDefault(col)
+  return def
+}
+
+const db = new Database('./data.sqlite')
+db.run('BEGIN')
+try {
+  for (const value of Object.values(schema)) {
+    if (!value || typeof value !== 'object') continue
+    let config
+    try {
+      config = getTableConfig(value as Parameters<typeof getTableConfig>[0])
+    } catch {
+      continue
+    }
+    const exists = db
+      .query(\`SELECT name FROM sqlite_master WHERE type='table' AND name=?\`)
+      .get(config.name)
+    if (!exists) {
+      const cols = config.columns.map((c) => colDef(c)).join(', ')
+      db.run(\`CREATE TABLE "\${config.name}" (\${cols})\`)
+      console.log(\`Created table: \${config.name}\`)
+    } else {
+      const existing = db.query(\`PRAGMA table_info("\${config.name}")\`).all() as { name: string }[]
+      const existingNames = new Set(existing.map((c) => c.name))
+      for (const col of config.columns) {
+        if (!existingNames.has(col.name)) {
+          db.run(\`ALTER TABLE "\${config.name}" ADD COLUMN \${colDef(col, true)}\`)
+          console.log(\`Added column: \${config.name}.\${col.name}\`)
+        }
+      }
+    }
+  }
+  db.run('COMMIT')
+} catch (e) {
+  db.run('ROLLBACK')
+  throw e
+}
+
+console.log('Schema push complete.')
 `
   )
 

--- a/src/main/lib/sandbox/app-manager.ts
+++ b/src/main/lib/sandbox/app-manager.ts
@@ -31,7 +31,7 @@ function pushSchema(appDir: string): void {
     copyFileSync(dbPath, backupPath);
   }
   try {
-    execSync('bunx drizzle-kit push --force', {
+    execSync('bun run src/db/push.ts', {
       cwd: appDir,
       stdio: 'pipe',
       timeout: 30_000


### PR DESCRIPTION
## Summary

Replace drizzle-kit dependency in generated web apps with a custom `src/db/push.ts` script that uses `bun:sqlite` natively. This eliminates the need for `better-sqlite3` in generated apps while maintaining schema management functionality.

## Changes

- Generate `src/db/push.ts` instead of `drizzle.config.ts` and remove `drizzle-kit` dependency
- Schema push via `bun:sqlite` + drizzle-orm's `getTableConfig()` API
- CREATE TABLE for new tables, ALTER TABLE ADD COLUMN for new columns
- Transaction wrapping for atomicity; automatic rollback on failure
- Proper handling of NOT NULL constraints in ALTER TABLE (skip when no default)
- String default value escaping to prevent SQL injection
- Fix SKILL.md UI guidance to match actual app panel location (right-click globe icon)

## Test Plan

- [x] Tests pass (75 tests)
- [x] Tested CREATE TABLE with default values
- [x] Tested ALTER TABLE ADD COLUMN with mixed constraints
- [x] Tested string default escaping (single quotes)
- [x] Verified transaction rollback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)