### PR TITLE
feat: support background task events from SDK

### DIFF
--- a/src/main/lib/claude-session.ts
+++ b/src/main/lib/claude-session.ts
@@ -461,6 +461,44 @@ export async function startStreamingSession(mainWindow: BrowserWindow | null): P
               });
             }
           }
+        } else if ((sdkMessage.subtype as string) === 'task_progress') {
+          // SDK types may not yet include task_progress — cast to access fields
+          const msg = sdkMessage as unknown as {
+            task_id: string;
+            tool_use_id?: string;
+            description: string;
+            usage: { total_tokens: number; tool_uses: number; duration_ms: number };
+            last_tool_name?: string;
+          };
+          mainWindow.webContents.send('chat:task-progress', {
+            taskId: msg.task_id,
+            toolUseId: msg.tool_use_id,
+            description: msg.description,
+            totalTokens: msg.usage.total_tokens,
+            toolUses: msg.usage.tool_uses,
+            durationMs: msg.usage.duration_ms,
+            lastToolName: msg.last_tool_name
+          });
+        } else if ((sdkMessage.subtype as string) === 'task_notification') {
+          // SDK types may not yet include task_notification — cast to access fields
+          const msg = sdkMessage as unknown as {
+            task_id: string;
+            tool_use_id?: string;
+            status: 'completed' | 'failed' | 'stopped';
+            output_file: string;
+            summary: string;
+            usage?: { total_tokens: number; tool_uses: number; duration_ms: number };
+          };
+          mainWindow.webContents.send('chat:task-notification', {
+            taskId: msg.task_id,
+            toolUseId: msg.tool_use_id,
+            status: msg.status,
+            outputFile: msg.output_file,
+            summary: msg.summary,
+            totalTokens: msg.usage?.total_tokens,
+            toolUses: msg.usage?.tool_uses,
+            durationMs: msg.usage?.duration_ms
+          });
         }
       }
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 import type { AnalyticsEvent, AnalyticsSettings, MessageFeedback } from '../shared/types/analytics';
+import type { TaskNotificationEvent, TaskProgressEvent } from '../shared/types/background-task';
 import type {
   AgentProvider,
   ChatModelPreference,
@@ -128,6 +129,18 @@ contextBridge.exposeInMainWorld('electron', {
       ) => callback(data);
       ipcRenderer.on('chat:session-updated', listener);
       return () => ipcRenderer.removeListener('chat:session-updated', listener);
+    },
+    onTaskProgress: (callback: (data: TaskProgressEvent) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, data: TaskProgressEvent) =>
+        callback(data);
+      ipcRenderer.on('chat:task-progress', listener);
+      return () => ipcRenderer.removeListener('chat:task-progress', listener);
+    },
+    onTaskNotification: (callback: (data: TaskNotificationEvent) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, data: TaskNotificationEvent) =>
+        callback(data);
+      ipcRenderer.on('chat:task-notification', listener);
+      return () => ipcRenderer.removeListener('chat:task-notification', listener);
     }
   },
   config: {

--- a/src/renderer/components/BackgroundTaskIndicator.tsx
+++ b/src/renderer/components/BackgroundTaskIndicator.tsx
@@ -1,0 +1,83 @@
+import { Activity, CheckCircle2, Loader2, XCircle } from 'lucide-react';
+
+import type { BackgroundTask } from '../../shared/types/background-task';
+
+interface BackgroundTaskIndicatorProps {
+  backgroundTasks: Map<string, BackgroundTask>;
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m${remainingSeconds}s`;
+}
+
+function StatusIcon({ status }: { status: BackgroundTask['status'] }) {
+  switch (status) {
+    case 'running':
+      return <Loader2 className="size-3.5 animate-spin text-blue-500 dark:text-blue-400" />;
+    case 'completed':
+      return <CheckCircle2 className="size-3.5 text-green-500 dark:text-green-400" />;
+    case 'failed':
+    case 'stopped':
+      return <XCircle className="size-3.5 text-red-500 dark:text-red-400" />;
+  }
+}
+
+export default function BackgroundTaskIndicator({
+  backgroundTasks
+}: BackgroundTaskIndicatorProps) {
+  const tasks = Array.from(backgroundTasks.values());
+
+  if (tasks.length === 0) return null;
+
+  const activeTasks = tasks.filter((t) => t.status === 'running');
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-2">
+      <div className="rounded-2xl border border-neutral-200/60 bg-white/95 shadow-lg shadow-black/5 backdrop-blur-xl dark:border-neutral-600/50 dark:bg-neutral-800/95 dark:shadow-black/30">
+        <div className="flex items-center gap-2 px-4 py-2">
+          <Activity className="size-4 text-neutral-500 dark:text-neutral-400" />
+          <span className="text-sm font-medium text-neutral-700 dark:text-neutral-200">
+            后台任务
+          </span>
+          {activeTasks.length > 0 && (
+            <span className="text-xs text-neutral-400">{activeTasks.length} 个运行中</span>
+          )}
+        </div>
+        <div className="border-t border-neutral-100 px-4 pt-1.5 pb-3 dark:border-neutral-700">
+          <div className="space-y-1.5">
+            {tasks.map((task) => (
+              <div key={task.taskId} className="flex items-start gap-2 py-0.5">
+                <span className="mt-0.5 flex-shrink-0">
+                  <StatusIcon status={task.status} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <span className="text-sm leading-snug text-neutral-700 dark:text-neutral-200">
+                    {task.description || '后台任务'}
+                  </span>
+                  <div className="flex flex-wrap items-center gap-2 text-[10px] text-neutral-400">
+                    {task.lastToolName && (
+                      <span className="rounded border border-neutral-200/50 bg-neutral-50/50 px-1 py-0.5 dark:border-neutral-600/50 dark:bg-neutral-900/50">
+                        {task.lastToolName}
+                      </span>
+                    )}
+                    <span>{formatDuration(task.durationMs)}</span>
+                    <span>{task.toolUses} 次工具调用</span>
+                    {task.summary && (
+                      <span className="text-neutral-500 dark:text-neutral-300">
+                        {task.summary}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,5 @@
 import type { AnalyticsEvent, AnalyticsSettings, MessageFeedback } from '../shared/types/analytics';
+import type { TaskNotificationEvent, TaskProgressEvent } from '../shared/types/background-task';
 import type {
   AgentProvider,
   AutoDetectResult,
@@ -353,6 +354,8 @@ export interface ElectronAPI {
     onSessionUpdated: (
       callback: (data: { sessionId: string; resumed: boolean }) => void
     ) => () => void;
+    onTaskProgress: (callback: (data: TaskProgressEvent) => void) => () => void;
+    onTaskNotification: (callback: (data: TaskNotificationEvent) => void) => () => void;
   };
   config: {
     getWorkspaceDir: () => Promise<WorkspaceResponse>;

--- a/src/renderer/hooks/useClaudeChat.ts
+++ b/src/renderer/hooks/useClaudeChat.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 
+import type { BackgroundTask } from '../../shared/types/background-task';
 import type { ToolUse } from '@/electron';
 import type { Message, ToolInput } from '@/types/chat';
 import { friendlyError } from '@/utils/friendlyError';
@@ -11,9 +12,11 @@ export function useClaudeChat(): {
   setMessages: Dispatch<SetStateAction<Message[]>>;
   isLoading: boolean;
   setIsLoading: Dispatch<SetStateAction<boolean>>;
+  backgroundTasks: Map<string, BackgroundTask>;
 } {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [backgroundTasks, setBackgroundTasks] = useState<Map<string, BackgroundTask>>(new Map());
   const isStreamingRef = useRef(false);
   const debugMessagesRef = useRef<string[]>([]);
 
@@ -482,6 +485,8 @@ export function useClaudeChat(): {
     const unsubscribeMessageComplete = window.electron.chat.onMessageComplete(() => {
       isStreamingRef.current = false;
       setIsLoading(false);
+      // Clear background tasks — session turn is done
+      setBackgroundTasks(new Map());
       window.electron.analytics.trackEvent({ type: 'message_completed', timestamp: Date.now() });
 
       // Append all accumulated debug messages when response completes
@@ -538,6 +543,8 @@ export function useClaudeChat(): {
     const unsubscribeMessageStopped = window.electron.chat.onMessageStopped(() => {
       isStreamingRef.current = false;
       setIsLoading(false);
+      // Clear background tasks — session was interrupted
+      setBackgroundTasks(new Map());
       window.electron.analytics.trackEvent({ type: 'message_stopped', timestamp: Date.now() });
 
       // Get accumulated debug messages
@@ -608,6 +615,8 @@ export function useClaudeChat(): {
     // Listen for errors
     const unsubscribeMessageError = window.electron.chat.onMessageError((error: string) => {
       isStreamingRef.current = false;
+      // Clear background tasks — session errored
+      setBackgroundTasks(new Map());
       window.electron.analytics.trackEvent({ type: 'message_error', timestamp: Date.now() });
 
       // Append all accumulated debug messages when error occurs
@@ -670,6 +679,45 @@ export function useClaudeChat(): {
       }
     });
 
+    // Listen for background task progress
+    const unsubscribeTaskProgress = window.electron.chat.onTaskProgress((data) => {
+      setBackgroundTasks((prev) => {
+        const next = new Map(prev);
+        next.set(data.taskId, {
+          taskId: data.taskId,
+          toolUseId: data.toolUseId,
+          description: data.description,
+          status: 'running',
+          totalTokens: data.totalTokens,
+          toolUses: data.toolUses,
+          durationMs: data.durationMs,
+          lastToolName: data.lastToolName
+        });
+        return next;
+      });
+    });
+
+    // Listen for background task notifications (completed/failed/stopped)
+    const unsubscribeTaskNotification = window.electron.chat.onTaskNotification((data) => {
+      setBackgroundTasks((prev) => {
+        const next = new Map(prev);
+        const existing = next.get(data.taskId);
+        next.set(data.taskId, {
+          taskId: data.taskId,
+          toolUseId: data.toolUseId,
+          description: existing?.description ?? '',
+          status: data.status,
+          totalTokens: data.totalTokens ?? existing?.totalTokens ?? 0,
+          toolUses: data.toolUses ?? existing?.toolUses ?? 0,
+          durationMs: data.durationMs ?? existing?.durationMs ?? 0,
+          lastToolName: existing?.lastToolName,
+          summary: data.summary,
+          outputFile: data.outputFile
+        });
+        return next;
+      });
+    });
+
     // Cleanup function to remove all event listeners
     return () => {
       unsubscribeMessageChunk();
@@ -685,6 +733,8 @@ export function useClaudeChat(): {
       unsubscribeMessageStopped();
       unsubscribeMessageError();
       unsubscribeDebugMessage();
+      unsubscribeTaskProgress();
+      unsubscribeTaskNotification();
     };
   }, []);
 
@@ -692,6 +742,7 @@ export function useClaudeChat(): {
     messages,
     setMessages,
     isLoading,
-    setIsLoading
+    setIsLoading,
+    backgroundTasks
   };
 }

--- a/src/renderer/pages/Chat.tsx
+++ b/src/renderer/pages/Chat.tsx
@@ -15,6 +15,7 @@ import type { Artifact } from '@/components/ArtifactPanel';
 import ArtifactPanel from '@/components/ArtifactPanel';
 import ChatInput from '@/components/ChatInput';
 import FileTree from '@/components/FileTree';
+import BackgroundTaskIndicator from '@/components/BackgroundTaskIndicator';
 import FloatingTaskPanel from '@/components/FloatingTaskPanel';
 import MessageList from '@/components/MessageList';
 import ResizeHandle from '@/components/ResizeHandle';
@@ -212,7 +213,7 @@ const Chat = forwardRef<ChatHandle, ChatProps>(function Chat(
   const appsRef = useRef(apps);
   appsRef.current = apps;
   const projectIdForNewChatRef = useRef<string | null>(null);
-  const { messages, setMessages, isLoading, setIsLoading } = useClaudeChat();
+  const { messages, setMessages, isLoading, setIsLoading, backgroundTasks } = useClaudeChat();
   const { track } = useAnalytics();
   const messagesContainerRef = useAutoScroll(isLoading, messages);
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -811,7 +812,12 @@ const Chat = forwardRef<ChatHandle, ChatProps>(function Chat(
                 isModelPreferenceUpdating={isModelPreferenceUpdating}
                 customModelActive={customModelActive}
                 customModelIds={customModelIds}
-                floatingPanel={<FloatingTaskPanel messages={messages} />}
+                floatingPanel={
+                  <>
+                    <BackgroundTaskIndicator backgroundTasks={backgroundTasks} />
+                    <FloatingTaskPanel messages={messages} />
+                  </>
+                }
               />
             </div>
           </>

--- a/src/shared/types/background-task.ts
+++ b/src/shared/types/background-task.ts
@@ -1,0 +1,33 @@
+export interface TaskProgressEvent {
+  taskId: string;
+  toolUseId?: string;
+  description: string;
+  totalTokens: number;
+  toolUses: number;
+  durationMs: number;
+  lastToolName?: string;
+}
+
+export interface TaskNotificationEvent {
+  taskId: string;
+  toolUseId?: string;
+  status: 'completed' | 'failed' | 'stopped';
+  outputFile: string;
+  summary: string;
+  totalTokens?: number;
+  toolUses?: number;
+  durationMs?: number;
+}
+
+export interface BackgroundTask {
+  taskId: string;
+  toolUseId?: string;
+  description: string;
+  status: 'running' | 'completed' | 'failed' | 'stopped';
+  totalTokens: number;
+  toolUses: number;
+  durationMs: number;
+  lastToolName?: string;
+  summary?: string;
+  outputFile?: string;
+}


### PR DESCRIPTION
## Summary
- Forward `task_progress` and `task_notification` system events from Claude Agent SDK through the IPC bridge to the renderer
- Add `BackgroundTaskIndicator` UI component showing running/completed/failed background sub-agent tasks with progress stats
- Clear background task state on session complete, stop, or error to prevent stale entries

## Test plan
- [ ] Trigger a background sub-agent (Agent tool with `run_in_background: true`) and verify progress updates appear in the floating panel
- [ ] Verify completed/failed/stopped tasks show correct status icons
- [ ] Verify tasks are cleared when the session completes, is stopped, or errors
- [ ] Verify `bun run lint && bun run typecheck && bun run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)