### PR TITLE
feat: 智能配置增强 — 详细进度日志 + 模型分档选择 + AI 推荐

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors';
 import { hmacAuth } from './middleware/hmac-auth';
 import { rateLimiter } from './middleware/rate-limit';
 import { parseRoute } from './routes/parse';
+import { recommendRoute } from './routes/recommend';
 
 const HMAC_SECRET = process.env.HMAC_SECRET || 'kfy7-1oO-1oo-OcQ-XxG-t9W-odp-LSm';
 
@@ -18,10 +19,15 @@ app.use(
   })
 );
 
-app.use('/api/*', rateLimiter({ windowMs: 60_000, max: 10 }));
 app.use('/api/*', hmacAuth(HMAC_SECRET));
 
+// General rate limit for parse endpoints
+app.use('/api/parse-config', rateLimiter({ windowMs: 60_000, max: 10 }));
+// Stricter rate limit for AI recommend (prevent abuse)
+app.use('/api/recommend-models', rateLimiter({ windowMs: 60_000, max: 3 }));
+
 app.route('/api', parseRoute);
+app.route('/api', recommendRoute);
 
 app.get('/health', (c) => c.json({ ok: true }));
 

--- a/server/src/routes/recommend.ts
+++ b/server/src/routes/recommend.ts
@@ -1,0 +1,72 @@
+import { Hono } from 'hono';
+import Anthropic from '@anthropic-ai/sdk';
+
+const EXTRACTOR_MODEL = process.env.EXTRACTOR_MODEL || 'anthropic/claude-haiku-4.5';
+
+const SYSTEM_PROMPT = `You are an AI model selector. Given a list of available model IDs, recommend the best model for each of 3 tiers:
+
+- fast (快速): Fastest and cheapest model for simple tasks. Prefer models with "mini", "flash", "haiku", "lite" in name.
+- smart-sonnet (均衡): Balanced model for everyday use at reasonable cost. Prefer models with "sonnet", "gpt-4.1", "gemini-2.0-flash", "deepseek-chat" in name.
+- smart-opus (强力): Most capable model for complex reasoning. Prefer models with "opus", "gpt-4.5", "o3", "gemini-2.5-pro", "deepseek-r1" in name.
+
+Rules:
+- Each recommended model MUST be from the provided list exactly (case-sensitive match)
+- Pick 3 DIFFERENT models when possible
+- Output ONLY valid JSON: {"fast": "model-id", "smart-sonnet": "model-id", "smart-opus": "model-id"}
+- If the list has fewer than 3 models, reuse models across tiers
+- NEVER include any text outside the JSON object`;
+
+interface RecommendResult {
+  fast?: string;
+  'smart-sonnet'?: string;
+  'smart-opus'?: string;
+  error?: string;
+}
+
+const client = new Anthropic();
+
+export async function recommendModels(models: string[]): Promise<RecommendResult> {
+  try {
+    const response = await client.messages.create({
+      model: EXTRACTOR_MODEL,
+      max_tokens: 256,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: `Available models:\n${models.join('\n')}` }],
+    });
+
+    const content = response.content[0];
+    if (content.type !== 'text') {
+      return { error: 'no_response' };
+    }
+
+    // Strip markdown code fences if present
+    const jsonText = content.text.replace(/^```(?:json)?\s*\n?/i, '').replace(/\n?```\s*$/i, '').trim();
+    const parsed = JSON.parse(jsonText) as RecommendResult;
+
+    if (!parsed.fast && !parsed['smart-sonnet'] && !parsed['smart-opus']) {
+      return { error: 'no_valid_recommendation' };
+    }
+
+    return parsed;
+  } catch {
+    return { error: 'recommend_failed' };
+  }
+}
+
+export const recommendRoute = new Hono();
+
+recommendRoute.post('/recommend-models', async (c) => {
+  const body = c.get('parsedBody') as { models?: string[] } | undefined;
+  const models = body?.models;
+
+  if (!models || !Array.isArray(models) || models.length === 0) {
+    return c.json({ error: 'models_required' }, 400);
+  }
+
+  if (models.length > 1000) {
+    return c.json({ error: 'too_many_models' }, 400);
+  }
+
+  const result = await recommendModels(models);
+  return c.json(result);
+});

--- a/src/main/handlers/config-handlers.ts
+++ b/src/main/handlers/config-handlers.ts
@@ -540,6 +540,8 @@ export function registerConfigHandlers(): void {
         success: boolean;
         model?: string;
         error?: string;
+        availableModels?: string[];
+        modelCount?: number;
       }> => {
         try {
           const base = baseUrl || 'https://api.openai.com';
@@ -552,8 +554,13 @@ export function registerConfigHandlers(): void {
             });
             if (modelsResp.ok) {
               const data = await modelsResp.json();
-              const firstModel = data.data?.[0]?.id;
-              return { success: true, model: firstModel || undefined };
+              const modelIds: string[] =
+                (data.data as Array<{ id: string }>)?.map((m) => m.id) || [];
+              return {
+                success: true,
+                modelCount: modelIds.length,
+                availableModels: modelIds
+              };
             }
           }
 
@@ -589,6 +596,8 @@ export function registerConfigHandlers(): void {
         success: boolean;
         model?: string;
         error?: string;
+        availableModels?: string[];
+        modelCount?: number;
       }> => {
         try {
           const client = new Anthropic({
@@ -624,24 +633,38 @@ export function registerConfigHandlers(): void {
       const probes: ProbeDetail[] = [];
 
       const firstResult = await first.probe();
-      probes.push({ provider: first.provider, ...firstResult });
+      probes.push({
+        provider: first.provider,
+        success: firstResult.success,
+        model: firstResult.model,
+        error: firstResult.error,
+        modelCount: firstResult.modelCount
+      });
       if (firstResult.success) {
         return {
           success: true,
           provider: first.provider,
           model: firstResult.model,
-          probes
+          probes,
+          availableModels: firstResult.availableModels
         };
       }
 
       const secondResult = await second.probe();
-      probes.push({ provider: second.provider, ...secondResult });
+      probes.push({
+        provider: second.provider,
+        success: secondResult.success,
+        model: secondResult.model,
+        error: secondResult.error,
+        modelCount: secondResult.modelCount
+      });
       if (secondResult.success) {
         return {
           success: true,
           provider: second.provider,
           model: secondResult.model,
-          probes
+          probes,
+          availableModels: secondResult.availableModels
         };
       }
 
@@ -650,6 +673,35 @@ export function registerConfigHandlers(): void {
         error: `两种接口均连接失败`,
         probes
       };
+    }
+  );
+
+  // Recommend models for 3 tiers via server-side AI
+  ipcMain.handle(
+    'config:recommend-models',
+    async (_event, params: { models: string[] }) => {
+      try {
+        const requestBody = JSON.stringify({ models: params.models });
+        const { timestamp, signature } = await signRequest(requestBody);
+        const response = await fetch(`${PARSE_SERVER_URL}/api/recommend-models`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-App-Timestamp': timestamp,
+            'X-App-Signature': signature
+          },
+          body: requestBody,
+          signal: AbortSignal.timeout(30_000)
+        });
+        if (!response.ok) {
+          const body = await response.json().catch(() => null);
+          return { error: body?.error || `HTTP ${response.status}` };
+        }
+        return await response.json();
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { error: message };
+      }
     }
   );
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -175,7 +175,9 @@ contextBridge.exposeInMainWorld('electron', {
     parseApiConfig: (params: { text: string }) =>
       ipcRenderer.invoke('config:parse-api-config', params),
     autoDetectProvider: (params: { apiKey: string; baseUrl?: string; modelId?: string }) =>
-      ipcRenderer.invoke('config:auto-detect-provider', params)
+      ipcRenderer.invoke('config:auto-detect-provider', params),
+    recommendModels: (params: { models: string[] }) =>
+      ipcRenderer.invoke('config:recommend-models', params)
   },
   shell: {
     openExternal: (url: string) => ipcRenderer.invoke('shell:open-external', url)

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -6,6 +6,7 @@ import type {
   ChatModelPreference,
   CustomModelIds,
   GetChatModelPreferenceResponse,
+  ModelRecommendation,
   OpenAIConfig,
   ParsedApiConfig,
   SendMessagePayload,
@@ -420,6 +421,9 @@ export interface ElectronAPI {
       baseUrl?: string;
       modelId?: string;
     }) => Promise<AutoDetectResult>;
+    recommendModels: (params: {
+      models: string[];
+    }) => Promise<ModelRecommendation & { error?: string }>;
   };
   shell: {
     openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -18,6 +18,13 @@ import {
   MODEL_TOOLTIPS
 } from '../../shared/types/ipc';
 
+const TIER_KEYS: ChatModelPreference[] = ['fast', 'smart-sonnet', 'smart-opus'];
+const TIER_LABELS: Record<ChatModelPreference, string> = {
+  fast: '快速',
+  'smart-sonnet': '均衡',
+  'smart-opus': '强力'
+};
+
 type ConfigMode = 'auto' | 'manual';
 type AutoConfigStatus = 'idle' | 'parsing' | 'parsed' | 'detecting' | 'saving' | 'success' | 'error';
 
@@ -132,6 +139,9 @@ function Settings() {
   const [detectedModel, setDetectedModel] = useState<string | null>(null);
   const [autoConfigError, setAutoConfigError] = useState<string | null>(null);
   const [autoConfigSteps, setAutoConfigSteps] = useState<AutoConfigStep[]>([]);
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [tierModels, setTierModels] = useState<Partial<Record<ChatModelPreference, string>>>({});
+  const [isRecommending, setIsRecommending] = useState(false);
 
   const [updateChannel, setUpdateChannel] = useState<UpdateChannel>('stable');
   const [isLoadingChannel, setIsLoadingChannel] = useState(true);
@@ -555,18 +565,24 @@ function Settings() {
       // Add individual probe results as sub-steps
       for (const probe of detectResult.probes || []) {
         const name = probe.provider === 'anthropic' ? 'Anthropic 接口' : 'OpenAI 接口';
-        pushStep({
-          label: name,
-          status: probe.success ? 'done' : 'error',
-          detail: probe.success
-            ? `连接成功${probe.model ? ` — 模型: ${probe.model}` : ''}`
-            : probe.error || '连接失败'
-        });
+        let detail: string;
+        if (probe.success) {
+          if (probe.modelCount) {
+            detail = `连接成功（${probe.modelCount} 个模型可用）`;
+          } else {
+            detail = `连接成功${probe.model ? ` — 模型: ${probe.model}` : ''}`;
+          }
+        } else {
+          detail = probe.error || '连接失败';
+        }
+        pushStep({ label: name, status: probe.success ? 'done' : 'error', detail });
       }
 
       if (detectResult.success && detectResult.provider) {
         setDetectedProvider(detectResult.provider);
         setDetectedModel(detectResult.model || null);
+        setAvailableModels(detectResult.availableModels || []);
+        setTierModels({});
         setAutoConfigStatus('parsed');
       } else {
         setAutoConfigStatus('error');
@@ -584,25 +600,27 @@ function Settings() {
 
     setAutoConfigStatus('saving');
     try {
+      // Resolve per-tier model IDs: user-selected tierModels > parsed modelId > empty
+      const resolvedModelIds: Partial<Record<ChatModelPreference, string>> = {};
+      for (const tier of TIER_KEYS) {
+        const selected = tierModels[tier];
+        if (selected) {
+          resolvedModelIds[tier] = selected;
+        } else if (parsedConfig.modelId) {
+          resolvedModelIds[tier] = parsedConfig.modelId;
+        }
+      }
+
       if (detectedProvider === 'anthropic') {
         await window.electron.config.setApiKey(parsedConfig.apiKey);
-        // Always clear then set — avoid stale values from previous config
         await window.electron.config.setApiBaseUrl(parsedConfig.baseUrl || null);
-        await window.electron.config.setCustomModelIds(
-          parsedConfig.modelId ?
-            {
-              fast: parsedConfig.modelId,
-              'smart-sonnet': parsedConfig.modelId,
-              'smart-opus': parsedConfig.modelId
-            }
-          : {}
-        );
+        await window.electron.config.setCustomModelIds(resolvedModelIds);
       } else {
-        // setOpenAIConfig replaces the entire openai config object
         await window.electron.config.setOpenAIConfig({
           apiKey: parsedConfig.apiKey,
           baseUrl: parsedConfig.baseUrl,
-          modelId: parsedConfig.modelId
+          // Use fast tier model as the single modelId for OpenAI
+          modelId: resolvedModelIds.fast || parsedConfig.modelId
         });
       }
 
@@ -622,6 +640,34 @@ function Settings() {
     }
   };
 
+  const handleRecommendModels = async () => {
+    if (availableModels.length === 0) return;
+    setIsRecommending(true);
+    try {
+      const result = await window.electron.config.recommendModels({
+        models: availableModels
+      });
+      if (result.error) {
+        setAutoConfigError(
+          result.error === 'rate_limit_exceeded'
+            ? 'AI 推荐请求过于频繁，请稍后再试'
+            : `AI 推荐失败: ${result.error}`
+        );
+      } else {
+        setTierModels({
+          fast: result.fast,
+          'smart-sonnet': result['smart-sonnet'],
+          'smart-opus': result['smart-opus']
+        });
+        setAutoConfigError(null);
+      }
+    } catch {
+      setAutoConfigError('AI 推荐失败，请手动选择');
+    } finally {
+      setIsRecommending(false);
+    }
+  };
+
   const resetAutoConfig = () => {
     setAutoConfigStatus('idle');
     setAutoConfigError(null);
@@ -629,6 +675,8 @@ function Settings() {
     setDetectedProvider(null);
     setDetectedModel(null);
     setAutoConfigSteps([]);
+    setAvailableModels([]);
+    setTierModels({});
   };
 
   const handleToggleUpdateChannel = async () => {
@@ -859,7 +907,7 @@ function Settings() {
 
                     {/* Parsed result preview */}
                     {parsedConfig && (autoConfigStatus === 'parsed' || autoConfigStatus === 'saving') && (
-                      <div className="space-y-2 rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-700 dark:bg-neutral-800">
+                      <div className="space-y-3 rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-700 dark:bg-neutral-800">
                         <p className="text-xs font-medium text-neutral-700 dark:text-neutral-300">
                           识别结果
                         </p>
@@ -878,12 +926,6 @@ function Settings() {
                               <span className="font-mono break-all">{parsedConfig.baseUrl}</span>
                             </div>
                           )}
-                          {parsedConfig.modelId && (
-                            <div className="flex gap-2">
-                              <span className="shrink-0 font-medium">模型:</span>
-                              <span className="font-mono">{parsedConfig.modelId}</span>
-                            </div>
-                          )}
                           {detectedProvider && (
                             <div className="flex gap-2">
                               <span className="shrink-0 font-medium">接口类型:</span>
@@ -892,12 +934,57 @@ function Settings() {
                               </span>
                             </div>
                           )}
-                          {detectedModel && (
-                            <div className="flex gap-2">
-                              <span className="shrink-0 font-medium">响应模型:</span>
-                              <span className="font-mono">{detectedModel}</span>
+                        </div>
+
+                        {/* Model tier selection */}
+                        <div className="space-y-2 border-t border-neutral-200 pt-2 dark:border-neutral-700">
+                          <div className="flex items-center justify-between">
+                            <p className="text-xs font-medium text-neutral-700 dark:text-neutral-300">
+                              模型配置
+                            </p>
+                            {availableModels.length > 0 && (
+                              <button
+                                onClick={handleRecommendModels}
+                                disabled={isRecommending}
+                                className="flex items-center gap-1 rounded px-2 py-0.5 text-[10px] font-medium text-neutral-600 transition-colors hover:bg-neutral-200 dark:text-neutral-400 dark:hover:bg-neutral-700"
+                              >
+                                {isRecommending ?
+                                  <Loader2 className="h-3 w-3 animate-spin" />
+                                : <Sparkles className="h-3 w-3" />}
+                                AI 推荐
+                              </button>
+                            )}
+                          </div>
+                          {TIER_KEYS.map((tier) => (
+                            <div key={tier} className="flex items-center gap-2">
+                              <label className="w-16 shrink-0 text-[11px] font-medium text-neutral-500 dark:text-neutral-400">
+                                {TIER_LABELS[tier]}
+                              </label>
+                              {availableModels.length > 0 ?
+                                <select
+                                  value={tierModels[tier] || ''}
+                                  onChange={(e) =>
+                                    setTierModels((prev) => ({ ...prev, [tier]: e.target.value || undefined }))
+                                  }
+                                  className="flex-1 rounded border border-neutral-300 bg-white px-2 py-1 font-mono text-[11px] text-neutral-700 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-300"
+                                >
+                                  <option value="">未指定（使用默认）</option>
+                                  {availableModels.map((m) => (
+                                    <option key={m} value={m}>{m}</option>
+                                  ))}
+                                </select>
+                              : <input
+                                  type="text"
+                                  value={tierModels[tier] || ''}
+                                  onChange={(e) =>
+                                    setTierModels((prev) => ({ ...prev, [tier]: e.target.value || undefined }))
+                                  }
+                                  placeholder={parsedConfig.modelId || '使用默认模型'}
+                                  className="flex-1 rounded border border-neutral-300 bg-white px-2 py-1 font-mono text-[11px] text-neutral-700 placeholder:text-neutral-400 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-300 dark:placeholder:text-neutral-500"
+                                />
+                              }
                             </div>
-                          )}
+                          ))}
                         </div>
                       </div>
                     )}

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -124,6 +124,8 @@ export interface ProbeDetail {
   success: boolean;
   model?: string;
   error?: string;
+  /** Available model IDs (when probe lists models) */
+  modelCount?: number;
 }
 
 /** Result of auto-detecting provider type */
@@ -134,6 +136,15 @@ export interface AutoDetectResult {
   error?: string;
   /** Details of each probe attempt, in order tried */
   probes?: ProbeDetail[];
+  /** Available model IDs from successful provider */
+  availableModels?: string[];
+}
+
+/** AI-recommended models for the 3 preference tiers */
+export interface ModelRecommendation {
+  fast: string;
+  'smart-sonnet': string;
+  'smart-opus': string;
 }
 
 /** Default OpenAI model IDs per preference tier */


### PR DESCRIPTION
## Summary
- 智能配置流程增加详细的步骤进度日志，每一步显示 ✓/✗/spinner 状态
- 连接成功后显示可用模型数量，并提供三档模型选择（快速/均衡/强力）
- 新增 AI 推荐按钮，调用服务端 LLM 为用户推荐三档模型
- 服务端新增 `/api/recommend-models` 端点（含独立 rate limit）
- 修复 OpenRouter 返回的 markdown code fence 导致 JSON 解析失败
- Extractor model 改为可配置（`EXTRACTOR_MODEL` 环境变量）

## Test plan
- [ ] 使用 OpenRouter API key 测试智能配置全流程
- [ ] 验证进度日志逐步显示
- [ ] 验证模型列表正确加载到三个下拉框
- [ ] 点击"AI 推荐"验证模型推荐结果
- [ ] 验证 rate limit 生效（recommend-models 3次/分钟）
- [ ] 验证无可用模型时的降级体验（文本输入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)