### PR TITLE
fix: refactor slash commands to invoke skills properly

### DIFF
--- a/src/renderer/components/ChatInput.tsx
+++ b/src/renderer/components/ChatInput.tsx
@@ -113,11 +113,7 @@ export default function ChatInput({
 
   const handleSlashSelect = useCallback(
     (item: Parameters<typeof SlashCommandMenu>[0]['items'][number]) => {
-      if (item.prefillPrompt) {
-        onChange(item.prefillPrompt);
-      } else {
-        onChange(`/${item.name} `);
-      }
+      onChange(`/${item.name} `);
       textareaRef.current?.focus();
     },
     [onChange]

--- a/src/renderer/components/SkillCardGrid.tsx
+++ b/src/renderer/components/SkillCardGrid.tsx
@@ -1,5 +1,5 @@
 import { ArrowRight, BarChart3, FileText, Globe, Palette, PenLine, Sparkles } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ComponentType, SVGProps } from 'react';
 
 import type { SkillCard } from '@/constants/skillCards';
@@ -15,7 +15,7 @@ const iconMap: Record<SkillCard['icon'], ComponentType<SVGProps<SVGSVGElement>>>
 };
 
 interface SkillCardGridProps {
-  onSelectSkill: (prefillPrompt: string) => void;
+  onSelectSkill: (slashCommand: string) => void;
   onMoreClick?: () => void;
   currentInput?: string;
 }
@@ -27,8 +27,24 @@ export default function SkillCardGrid({
 }: SkillCardGridProps) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [confirmedInput, setConfirmedInput] = useState<string | null>(null);
+  const [installedSkillNames, setInstalledSkillNames] = useState<Set<string> | null>(null);
 
-  const selectedCard = skillCards.find((c) => c.id === selectedId);
+  useEffect(() => {
+    window.electron.skill
+      .list()
+      .then(({ skills }) => setInstalledSkillNames(new Set(skills.map((s) => s.name))))
+      .catch(() => {});
+  }, []);
+
+  const visibleCards = useMemo(
+    () =>
+      skillCards.filter(
+        (card) => card.id === 'more' || !installedSkillNames || installedSkillNames.has(card.id)
+      ),
+    [installedSkillNames]
+  );
+
+  const selectedCard = visibleCards.find((c) => c.id === selectedId);
   const isConfirmed = confirmedInput !== null && confirmedInput === currentInput;
 
   const handlePillClick = useCallback(
@@ -44,15 +60,15 @@ export default function SkillCardGrid({
     [onMoreClick]
   );
 
-  const handleUsePrompt = useCallback(() => {
-    if (!selectedCard?.prefillPrompt) return;
+  const handleUseSkill = useCallback(() => {
+    if (!selectedCard || selectedCard.id === 'more') return;
 
     if (currentInput.trim() && !isConfirmed) {
       setConfirmedInput(currentInput);
       return;
     }
 
-    onSelectSkill(selectedCard.prefillPrompt);
+    onSelectSkill(`/${selectedCard.id} `);
     setSelectedId(null);
     setConfirmedInput(null);
   }, [selectedCard, currentInput, isConfirmed, onSelectSkill]);
@@ -61,7 +77,7 @@ export default function SkillCardGrid({
     <div className="flex w-full max-w-2xl flex-col items-center gap-3 px-4">
       {/* Pill tags */}
       <div className="flex flex-wrap justify-center gap-2">
-        {skillCards.map((card) => {
+        {visibleCards.map((card) => {
           const Icon = iconMap[card.icon];
           const isSelected = card.id === selectedId;
           return (
@@ -133,10 +149,10 @@ export default function SkillCardGrid({
             </div>
 
             <button
-              onClick={handleUsePrompt}
+              onClick={handleUseSkill}
               className="flex items-center gap-1 rounded-lg bg-neutral-800 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-neutral-700 dark:bg-neutral-200 dark:text-neutral-800 dark:hover:bg-neutral-300"
             >
-              {isConfirmed ? '确认替换当前输入' : '使用此场景'}
+              {isConfirmed ? '确认替换当前输入' : '使用此技能'}
               <ArrowRight className="h-3 w-3" />
             </button>
           </div>

--- a/src/renderer/constants/skillCards.ts
+++ b/src/renderer/constants/skillCards.ts
@@ -4,7 +4,6 @@ export interface SkillCard {
   description: string;
   icon: 'FileText' | 'BarChart3' | 'PenLine' | 'Globe' | 'Palette' | 'Sparkles';
   iconColor: string;
-  prefillPrompt: string | null;
   /** Detail card content shown when the pill is selected */
   detail?: {
     background: string;
@@ -20,8 +19,6 @@ export const skillCards: SkillCard[] = [
     description: '根据描述快速生成网页应用',
     icon: 'Globe',
     iconColor: '#8B5CF6',
-    prefillPrompt:
-      '帮我创建一个露营团建住宿统计页面，同事打开链接后可以填写自己的姓名、选择住营地还是当天返回，提交后我能实时看到汇总结果。',
     detail: {
       background:
         '公司安排小张组织一次露营形式的团建，他需要提前统计每个人是住在营地还是当天返回，方便安排帐篷和交通。',
@@ -36,8 +33,6 @@ export const skillCards: SkillCard[] = [
     description: '提取内容、合并拆分、填写表单',
     icon: 'FileText',
     iconColor: '#EF4444',
-    prefillPrompt:
-      '请帮我把附件中这份对账单 PDF 里的表格数据提取出来，整理成 Excel 表格，方便我逐项核对。',
     detail: {
       background:
         '财务小李每月要核对十几家供应商发来的对账单，但对账单都是 PDF 格式，手动逐行比对既慢又容易出错。',
@@ -52,8 +47,6 @@ export const skillCards: SkillCard[] = [
     description: '数据分析、图表制作、公式计算',
     icon: 'BarChart3',
     iconColor: '#22C55E',
-    prefillPrompt:
-      '请分析附件中上季度各渠道的销售数据，找出增长最快和下滑最明显的渠道，做成带图表的分析报告。',
     detail: {
       background:
         '市场部小王拿到了上季度各销售渠道的数据表，领导下周要看各渠道的增长情况，让他准备一份分析报告。',
@@ -68,8 +61,6 @@ export const skillCards: SkillCard[] = [
     description: '创建、审阅、批注 Word 文档',
     icon: 'PenLine',
     iconColor: '#3B82F6',
-    prefillPrompt:
-      '请帮我检查附件中的年会活动方案，看看有没有措辞不当、逻辑不通或格式不规范的地方，标注出来并给出修改建议。',
     detail: {
       background:
         '行政小陈写好了公司年会的活动方案，提交给领导前想先检查一遍，避免有错别字或者逻辑漏洞。',
@@ -84,8 +75,6 @@ export const skillCards: SkillCard[] = [
     description: '打造高品质的前端页面',
     icon: 'Palette',
     iconColor: '#EC4899',
-    prefillPrompt:
-      '帮我设计一个内部数据看板页面，能展示今日订单量、销售额、客户数等关键指标，风格简洁清晰。',
     detail: {
       background:
         '运营主管每天早上要登录好几个系统分别查看业务数据，想要一个页面能一眼看到所有关键指标。',
@@ -99,7 +88,6 @@ export const skillCards: SkillCard[] = [
     title: '更多场景',
     description: '探索其他能力',
     icon: 'Sparkles',
-    iconColor: '#6B7280',
-    prefillPrompt: null
+    iconColor: '#6B7280'
   }
 ];

--- a/src/renderer/hooks/useSlashCommand.ts
+++ b/src/renderer/hooks/useSlashCommand.ts
@@ -9,36 +9,23 @@ export interface SlashCommandItem {
   name: string;
   displayName: string;
   description: string;
-  /** If set, selecting this item replaces the entire input with this prompt */
-  prefillPrompt: string | null;
 }
+
+/** Map from skill card id to its friendly metadata */
+const cardsByName = new Map(
+  skillCards.filter((c) => c.id !== 'more').map((c) => [c.id, c])
+);
 
 function buildSlashItems(installedSkills: SkillInfo[]): SlashCommandItem[] {
   const items: SlashCommandItem[] = [];
-  const seen = new Set<string>();
 
-  // Skill cards first (they have friendly Chinese titles and prefill prompts)
-  for (const card of skillCards) {
-    if (!card.prefillPrompt) continue;
-    seen.add(card.id);
-    items.push({
-      id: `card-${card.id}`,
-      name: card.id,
-      displayName: card.title,
-      description: card.description,
-      prefillPrompt: card.prefillPrompt
-    });
-  }
-
-  // Installed skills not already covered by cards
   for (const skill of installedSkills) {
-    if (seen.has(skill.name)) continue;
+    const card = cardsByName.get(skill.name);
     items.push({
-      id: `skill-${skill.name}`,
+      id: card ? `card-${card.id}` : `skill-${skill.name}`,
       name: skill.name,
-      displayName: skill.name,
-      description: skill.manifest?.description ?? '',
-      prefillPrompt: null
+      displayName: card?.title ?? skill.name,
+      description: card?.description ?? skill.manifest?.description ?? ''
     });
   }
 

--- a/src/renderer/pages/Chat.tsx
+++ b/src/renderer/pages/Chat.tsx
@@ -770,7 +770,18 @@ const Chat = forwardRef<ChatHandle, ChatProps>(function Chat(
               />
             </div>
             <SkillCardGrid
-              onSelectSkill={(prompt) => setInputValue(prompt)}
+              onSelectSkill={(cmd) => {
+                setInputValue(cmd);
+                requestAnimationFrame(() => {
+                  const textarea = document.querySelector<HTMLTextAreaElement>(
+                    'textarea[placeholder]'
+                  );
+                  if (textarea) {
+                    textarea.focus();
+                    textarea.setSelectionRange(cmd.length, cmd.length);
+                  }
+                });
+              }}
               onMoreClick={onSkillsClick}
               currentInput={inputValue}
             />


### PR DESCRIPTION
## Summary

Refactored slash command flow to properly invoke skills. Users now type `/{skillName} ` + their request, allowing the Claude Agent SDK to recognize the pattern and invoke the Skill tool correctly, rather than being misled by pre-filled example prompts.

- Removed `prefillPrompt` from skill cards and slash command data structures
- Only show skills in slash menu and home page cards if they are installed  
- Auto-focus input field after selecting skill from home page
- Updated button text from "使用此场景" to "使用此技能" to reflect new behavior

## Test plan

- Select skill from slash menu (/) — input should be `/{skillName} ` with cursor focused and ready for typing
- Select skill from home page cards — input field auto-focuses after selection
- Type request after skill name and send — LLM recognizes `/skillName` and invokes Skill tool
- Only installed skills should appear in slash menu and home page cards

🤖 Generated with Claude Code