### PR TITLE
fix(chat): 修复流式渲染布局重叠和 detectLanguage 崩溃

### DIFF
--- a/src/renderer/components/Message.tsx
+++ b/src/renderer/components/Message.tsx
@@ -518,7 +518,7 @@ const Message = forwardRef<HTMLDivElement, MessageProps>(function Message(
     <div ref={ref}>
       <AIMessage from="assistant" className="max-w-full">
         <MessageContent className="w-full px-3 py-2 text-base leading-relaxed">
-          <div className="space-y-3">
+          <div className="space-y-3 overflow-hidden">
             {groupedBlocks.map((item, index) => {
               // Single text block
               if (!Array.isArray(item)) {

--- a/src/renderer/components/ai-elements/message.tsx
+++ b/src/renderer/components/ai-elements/message.tsx
@@ -325,7 +325,7 @@ export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
     <Streamdown
       className={cn(
-        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        "w-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
         className
       )}
       {...props}

--- a/src/renderer/components/ai-elements/reasoning.tsx
+++ b/src/renderer/components/ai-elements/reasoning.tsx
@@ -146,7 +146,7 @@ export const ReasoningContent = memo(
     <CollapsibleContent
       className={cn(
         "mt-4 text-sm",
-        "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-muted-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "text-muted-foreground outline-none",
         className
       )}
       {...props}

--- a/src/renderer/components/ai-elements/tool.tsx
+++ b/src/renderer/components/ai-elements/tool.tsx
@@ -125,7 +125,7 @@ export type ToolContentProps = ComponentProps<typeof CollapsibleContent>;
 export const ToolContent = ({ className, ...props }: ToolContentProps) => (
   <CollapsibleContent
     className={cn(
-      "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+      "text-popover-foreground outline-none",
       className
     )}
     {...props}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -224,6 +224,7 @@ pre code {
   min-width: 0;
   flex-direction: column;
   gap: 0.75rem;
+  overflow: hidden;
 }
 
 .expanded-block-section .collapsible-tool-expanded {

--- a/src/renderer/lib/ai-elements-adapters.ts
+++ b/src/renderer/lib/ai-elements-adapters.ts
@@ -290,7 +290,8 @@ export function parseGlobToTree(result: string): FileTreeNode[] {
   return finalizeTree([...root.values()]);
 }
 
-export function detectLanguage(filePath: string): BundledLanguage {
+export function detectLanguage(filePath: string | undefined): BundledLanguage {
+  if (!filePath) return 'markdown';
   const normalizedPath = normalizePath(filePath);
   const basename = normalizedPath.split('/').pop()?.toLowerCase() ?? '';
   const extension = basename.includes('.') ? basename.split('.').pop() ?? '' : basename;


### PR DESCRIPTION
## Summary
- 修复流式输出时文字、工具块、状态 badge 之间的 CSS 布局重叠问题
- 修复 `detectLanguage` 在工具输入流式解析中间状态接收 `undefined` 导致的崩溃 (Sentry MA-AGENT-2)

## 变更

### 布局重叠 (3 个根因)
- `MessageResponse`: `size-full` → `w-full`，移除多余的 `height:100%` 避免高度竞争
- `ToolContent` / `ReasoningContent`: 移除 slide/fade 动画，消除 CSS transform 导致的视觉重叠
- 添加 `overflow-hidden` 到消息内容容器和 `.expanded-block-section`

### 崩溃修复
- `detectLanguage()` 签名改为接受 `string | undefined`，提前返回 `'markdown'`
- 一次性保护所有调用方 (ReadTool, EditTool, WriteTool, NotebookEditTool)

## Test plan
- [x] 发送消息触发流式输出，观察文字不再重叠
- [x] 展开/折叠工具和思考块，确认无布局跳动
- [x] 在工具输入流式解析阶段（Read/Edit/Write 工具），确认无崩溃
- [x] Lint + TypeCheck 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)